### PR TITLE
test: added service layer tests

### DIFF
--- a/backend/src/test/java/se/voizter/felparkering/api/service/AddressServiceTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/service/AddressServiceTests.java
@@ -1,6 +1,11 @@
 package se.voizter.felparkering.api.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.address;
+
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,6 +14,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestClient;
 
+import se.voizter.felparkering.api.dto.AddressSuggestionDto;
+import se.voizter.felparkering.api.model.Address;
 import se.voizter.felparkering.api.repository.AddressRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,11 +48,25 @@ public class AddressServiceTests {
 
     @Test
     void returnsSuggestionsFromMatchingAddresses() {
-        // TODO: Write test
+        Address address = address(1L, "Kungsgatan", List.of("1", "3"), "Goteborg");
+
+        when(addressRepository.searchByStreet("kung"))
+            .thenReturn(List.of(address));
+
+        List<AddressSuggestionDto> result = addressService.getAddresses("kung");
+
+        assertEquals(2, result.size());
+        assertEquals(new AddressSuggestionDto(1L, "Kungsgatan", "Goteborg", "1"), result.get(0));
+        assertEquals(new AddressSuggestionDto(1L, "Kungsgatan", "Goteborg", "3"), result.get(1));
     }
 
     @Test
     void returnsEmptyListWhenRepositoryReturnsEmptyList() {
-        // TODO: Write test
+        when(addressRepository.searchByStreet("missing"))
+            .thenReturn(List.of());
+
+        List<AddressSuggestionDto> result = addressService.getAddresses("missing");
+
+        assertTrue(result.isEmpty());
     }
 }

--- a/backend/src/test/java/se/voizter/felparkering/api/service/AdminServiceTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/service/AdminServiceTests.java
@@ -1,11 +1,25 @@
 package se.voizter.felparkering.api.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.adminUserWithId;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.attendantGroup;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.attendantUserWithId;
+
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import se.voizter.felparkering.api.dto.AttendantGroupDetailDto;
+import se.voizter.felparkering.api.dto.UserAdminDetailDto;
+import se.voizter.felparkering.api.enums.Role;
+import se.voizter.felparkering.api.model.User;
 import se.voizter.felparkering.api.repository.AttendantGroupRepository;
 import se.voizter.felparkering.api.repository.UserRepository;
 
@@ -23,26 +37,53 @@ public class AdminServiceTests {
 
     @Test
     void getAllUsersReturnsUserDTOsForAllUsers() {
-        // TODO: Write test
+        when(userRepository.findAll())
+            .thenReturn(List.of(adminUserWithId(1L), attendantUserWithId(2L)));
+
+        List<UserAdminDetailDto> result = adminService.getAllUsers();
+
+        assertEquals(2, result.size());
+        assertEquals(new UserAdminDetailDto(1L, Role.ADMIN), result.get(0));
+        assertEquals(new UserAdminDetailDto(2L, Role.ATTENDANT), result.get(1));
     }
 
     @Test
     void createAttendantSavesUser() {
-        // TODO: Write test
+        User attendant = attendantUserWithId(3L);
+
+        adminService.createAttendant(attendant);
+
+        verify(userRepository).save(attendant);
     }
 
     @Test
     void createAttendantReturnsDTOWithIdAndRole() {
-        // TODO: Write test
+        User attendant = attendantUserWithId(3L);
+
+        UserAdminDetailDto result = adminService.createAttendant(attendant);
+
+        assertEquals(3L, result.id());
+        assertEquals(Role.ATTENDANT, result.role());
     }
 
     @Test
     void deleteUserDeletesById() {
-        // TODO: Write test
+        adminService.deleteUser(9L);
+
+        verify(userRepository).deleteById(9L);
     }
 
     @Test
     void getAllAttendantGroupsReturnsGroupDTOs() {
-        // TODO: Write test
+        when(groupRepository.findAll())
+            .thenReturn(List.of(attendantGroup(1L, "Goteborg"), attendantGroup(2L, "Stockholm")));
+
+        List<AttendantGroupDetailDto> result = adminService.getAllAttendantGroups();
+
+        assertEquals(2, result.size());
+        assertEquals("Goteborg", result.get(0).name());
+        assertNull(result.get(0).attendants());
+        assertEquals("Stockholm", result.get(1).name());
+        assertNull(result.get(1).attendants());
     }
 }

--- a/backend/src/test/java/se/voizter/felparkering/api/service/AuthServiceTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/service/AuthServiceTests.java
@@ -1,11 +1,31 @@
 package se.voizter.felparkering.api.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.customerUserWithId;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.loginRequest;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.registerRequest;
+
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import se.voizter.felparkering.api.dto.UserDetailDto;
+import se.voizter.felparkering.api.enums.Role;
+import se.voizter.felparkering.api.exception.exceptions.InvalidCredentialsException;
+import se.voizter.felparkering.api.exception.exceptions.NotFoundException;
+import se.voizter.felparkering.api.exception.exceptions.PasswordMismatchException;
+import se.voizter.felparkering.api.exception.exceptions.UserConflictException;
+import se.voizter.felparkering.api.model.User;
 import se.voizter.felparkering.api.repository.UserRepository;
 import se.voizter.felparkering.api.security.JwtProvider;
 
@@ -23,31 +43,86 @@ public class AuthServiceTests {
 
     @Test
     void loginReturnsTokenWhenCredentialsAreValid() {
-        // TODO: Write test
+        User user = customerUserWithId(10L);
+        when(userRepository.findByEmail("customer@example.com"))
+            .thenReturn(Optional.of(user));
+        when(jwtProvider.generateToken(10L, Role.CUSTOMER))
+            .thenReturn("jwt-token");
+
+        UserDetailDto result = authService.login(loginRequest("customer@example.com", "password123"));
+
+        assertEquals("jwt-token", result.token());
     }
 
     @Test
     void loginThrowsNotFoundExceptionWhenEmailIsMissing() {
-        // TODO: Write test
+        when(userRepository.findByEmail("missing@example.com"))
+            .thenReturn(Optional.empty());
+
+        assertThrows(
+            NotFoundException.class,
+            () -> authService.login(loginRequest("missing@example.com", "password123"))
+        );
+        verify(jwtProvider, never()).generateToken(any(), any());
     }
 
     @Test
     void loginThrowsInvalidCredentialsExceptionWhenPasswordIsWrong() {
-        // TODO: Write test
+        User user = customerUserWithId(10L);
+        when(userRepository.findByEmail("customer@example.com"))
+            .thenReturn(Optional.of(user));
+
+        assertThrows(
+            InvalidCredentialsException.class,
+            () -> authService.login(loginRequest("customer@example.com", "wrongpass"))
+        );
+        verify(jwtProvider, never()).generateToken(any(), any());
     }
 
     @Test
     void registerSavesCustomerAndReturnsToken() {
-        // TODO: Write test
+        when(userRepository.findByEmail("new@example.com"))
+            .thenReturn(Optional.empty());
+        when(jwtProvider.generateToken(null, Role.CUSTOMER))
+            .thenReturn("new-token");
+
+        UserDetailDto result = authService.register(
+            registerRequest("new@example.com", "password123", "password123")
+        );
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        User saved = userCaptor.getValue();
+        assertEquals("new@example.com", saved.getEmail());
+        assertEquals("password123", saved.getPassword());
+        assertEquals(Role.CUSTOMER, saved.getRole());
+        assertEquals("new-token", result.token());
     }
 
     @Test
     void registerThrowsUserConflictExceptionWhenEmailAlreadyExists() {
-        // TODO: Write test
+        when(userRepository.findByEmail("existing@example.com"))
+            .thenReturn(Optional.of(customerUserWithId(1L)));
+
+        assertThrows(
+            UserConflictException.class,
+            () -> authService.register(registerRequest("existing@example.com", "password123", "password123"))
+        );
+        verify(userRepository, never()).save(any());
+        verify(jwtProvider, never()).generateToken(any(), any());
     }
 
     @Test
     void registerThrowsPasswordMismatchExceptionWhenPasswordsDiffer() {
-        // TODO: Write test
+        when(userRepository.findByEmail("new@example.com"))
+            .thenReturn(Optional.empty());
+
+        assertThrows(
+            PasswordMismatchException.class,
+            () -> authService.register(registerRequest("new@example.com", "password123", "different123"))
+        );
+        verify(userRepository, never()).save(any());
+        verify(jwtProvider, never()).generateToken(any(), any());
     }
+
 }

--- a/backend/src/test/java/se/voizter/felparkering/api/service/ReportServiceTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/service/ReportServiceTests.java
@@ -1,11 +1,47 @@
 package se.voizter.felparkering.api.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.address;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.adminUserWithId;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.attendantGroup;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.attendantUserWithId;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.customerUserWithId;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.report;
+import static se.voizter.felparkering.api.testsupport.TestDataFactory.reportRequest;
+
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
+import se.voizter.felparkering.api.dto.ReportDetailDto;
+import se.voizter.felparkering.api.dto.UserRequest;
+import se.voizter.felparkering.api.enums.ParkingViolationCategory;
+import se.voizter.felparkering.api.enums.Status;
+import se.voizter.felparkering.api.exception.exceptions.AlreadyAssignedException;
+import se.voizter.felparkering.api.exception.exceptions.InvalidCredentialsException;
+import se.voizter.felparkering.api.exception.exceptions.NotFoundException;
+import se.voizter.felparkering.api.model.Address;
+import se.voizter.felparkering.api.model.AttendantGroup;
+import se.voizter.felparkering.api.model.Report;
+import se.voizter.felparkering.api.model.User;
 import se.voizter.felparkering.api.repository.AddressRepository;
 import se.voizter.felparkering.api.repository.AttendantGroupRepository;
 import se.voizter.felparkering.api.repository.ReportRepository;
@@ -35,174 +71,456 @@ public class ReportServiceTests {
 
     @Test
     void createReturnsReportWhenCustomerCreatesValidReport() {
-        // TODO: Write test
+        User customer = customerUserWithId(1L);
+        Address address = address(10L, "Kungsgatan", "15", "Goteborg");
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        when(addressRepository.findById(10L)).thenReturn(Optional.of(address));
+        when(groupRepository.findByName("Goteborg")).thenReturn(Optional.of(group));
+
+        ReportDetailDto result = reportService.create(
+            customer,
+            reportRequest(10L, "Kungsgatan", "15", "Goteborg", "abc123", ParkingViolationCategory.NO_PARKING_FEE_PAID)
+        );
+
+        assertEquals(address, result.address());
+        assertEquals("ABC123", result.licensePlate());
+        assertEquals(ParkingViolationCategory.NO_PARKING_FEE_PAID, result.category());
+        assertEquals(group, result.attendantGroup());
+        assertEquals(Status.NEW, result.status());
     }
 
     @Test
     void createReturnsReportWhenAdminCreatesValidReport() {
-        // TODO: Write test
+        User admin = adminUserWithId(2L);
+        Address address = address(10L, "Kungsgatan", "15", "Goteborg");
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        when(addressRepository.findById(10L)).thenReturn(Optional.of(address));
+        when(groupRepository.findByName("Goteborg")).thenReturn(Optional.of(group));
+
+        ReportDetailDto result = reportService.create(
+            admin,
+            reportRequest(10L, "Kungsgatan", "15", "Goteborg", "abc123", ParkingViolationCategory.NO_PARKING_FEE_PAID)
+        );
+
+        assertEquals("ABC123", result.licensePlate());
+        assertEquals(Status.NEW, result.status());
     }
 
     @Test
     void createThrowsInvalidCredentialsWhenAttendantCreatesReport() {
-        // TODO: Write test
+        User attendant = attendantUserWithId(3L);
+
+        assertThrows(
+            InvalidCredentialsException.class,
+            () -> reportService.create(
+                attendant,
+                reportRequest(10L, "Kungsgatan", "15", "Goteborg", "abc123", ParkingViolationCategory.NO_PARKING_FEE_PAID)
+            )
+        );
+        verify(reportRepository, never()).save(any());
     }
 
     @Test
     void createThrowsNotFoundWhenAddressDoesNotExist() {
-        // TODO: Write test
+        when(addressRepository.findById(10L)).thenReturn(Optional.empty());
+
+        assertThrows(
+            NotFoundException.class,
+            () -> reportService.create(
+                customerUserWithId(1L),
+                reportRequest(10L, "Kungsgatan", "15", "Goteborg", "abc123", ParkingViolationCategory.NO_PARKING_FEE_PAID)
+            )
+        );
+        verify(reportRepository, never()).save(any());
     }
 
     @Test
     void createThrowsNotFoundWhenAttendantGroupDoesNotExist() {
-        // TODO: Write test
+        Address address = address(10L, "Kungsgatan", "15", "Goteborg");
+        when(addressRepository.findById(10L)).thenReturn(Optional.of(address));
+        when(groupRepository.findByName("Goteborg")).thenReturn(Optional.empty());
+
+        assertThrows(
+            NotFoundException.class,
+            () -> reportService.create(
+                customerUserWithId(1L),
+                reportRequest(10L, "Kungsgatan", "15", "Goteborg", "abc123", ParkingViolationCategory.NO_PARKING_FEE_PAID)
+            )
+        );
+        verify(reportRepository, never()).save(any());
     }
 
     @Test
     void createUppercasesLicensePlate() {
-        // TODO: Write test
+        when(addressRepository.findById(10L)).thenReturn(Optional.of(address(10L, "Kungsgatan", "15", "Goteborg")));
+        when(groupRepository.findByName("Goteborg")).thenReturn(Optional.of(attendantGroup(20L, "Goteborg")));
+
+        reportService.create(
+            customerUserWithId(1L),
+            reportRequest(10L, "Kungsgatan", "15", "Goteborg", "abc123", ParkingViolationCategory.NO_PARKING_FEE_PAID)
+        );
+
+        ArgumentCaptor<Report> reportCaptor = ArgumentCaptor.forClass(Report.class);
+        verify(reportRepository).save(reportCaptor.capture());
+        assertEquals("ABC123", reportCaptor.getValue().getLicensePlate());
     }
 
     @Test
     void createSetsStatusToNew() {
-        // TODO: Write test
+        when(addressRepository.findById(10L)).thenReturn(Optional.of(address(10L, "Kungsgatan", "15", "Goteborg")));
+        when(groupRepository.findByName("Goteborg")).thenReturn(Optional.of(attendantGroup(20L, "Goteborg")));
+
+        reportService.create(
+            customerUserWithId(1L),
+            reportRequest(10L, "Kungsgatan", "15", "Goteborg", "abc123", ParkingViolationCategory.NO_PARKING_FEE_PAID)
+        );
+
+        ArgumentCaptor<Report> reportCaptor = ArgumentCaptor.forClass(Report.class);
+        verify(reportRepository).save(reportCaptor.capture());
+        assertEquals(Status.NEW, reportCaptor.getValue().getStatus());
     }
 
     @Test
     void createSetsCreatedByUser() {
-        // TODO: Write test
+        User customer = customerUserWithId(1L);
+        when(addressRepository.findById(10L)).thenReturn(Optional.of(address(10L, "Kungsgatan", "15", "Goteborg")));
+        when(groupRepository.findByName("Goteborg")).thenReturn(Optional.of(attendantGroup(20L, "Goteborg")));
+
+        reportService.create(
+            customer,
+            reportRequest(10L, "Kungsgatan", "15", "Goteborg", "abc123", ParkingViolationCategory.NO_PARKING_FEE_PAID)
+        );
+
+        ArgumentCaptor<Report> reportCaptor = ArgumentCaptor.forClass(Report.class);
+        verify(reportRepository).save(reportCaptor.capture());
+        assertSame(customer, reportCaptor.getValue().getCreatedBy());
     }
 
     @Test
     void createSetsAttendantGroupFromAddressCity() {
-        // TODO: Write test
+        Address address = address(10L, "Kungsgatan", "15", "Goteborg");
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        when(addressRepository.findById(10L)).thenReturn(Optional.of(address));
+        when(groupRepository.findByName("Goteborg")).thenReturn(Optional.of(group));
+
+        reportService.create(
+            customerUserWithId(1L),
+            reportRequest(10L, "Kungsgatan", "15", "Goteborg", "abc123", ParkingViolationCategory.NO_PARKING_FEE_PAID)
+        );
+
+        ArgumentCaptor<Report> reportCaptor = ArgumentCaptor.forClass(Report.class);
+        verify(reportRepository).save(reportCaptor.capture());
+        assertSame(group, reportCaptor.getValue().getAttendantGroup());
     }
 
     @Test
     void getReturnsReportWhenAdminRequestsAnyReport() {
-        // TODO: Write test
+        Report report = report(100L, customerUserWithId(1L), attendantGroup(20L, "Goteborg"), Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        ReportDetailDto result = reportService.get(adminUserWithId(2L), 100L);
+
+        assertEquals(100L, result.id());
     }
 
     @Test
     void getReturnsReportWhenCustomerRequestsOwnReport() {
-        // TODO: Write test
+        User customer = customerUserWithId(1L);
+        Report report = report(100L, customer, attendantGroup(20L, "Goteborg"), Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        ReportDetailDto result = reportService.get(customer, 100L);
+
+        assertEquals(100L, result.id());
     }
 
     @Test
     void getThrowsInvalidCredentialsWhenCustomerRequestsOtherUsersReport() {
-        // TODO: Write test
+        Report report = report(100L, customerUserWithId(1L), attendantGroup(20L, "Goteborg"), Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        assertThrows(
+            InvalidCredentialsException.class,
+            () -> reportService.get(customerUserWithId(2L), 100L)
+        );
     }
 
     @Test
     void getReturnsReportWhenAttendantRequestsReportInSameGroup() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User attendant = attendantUserWithId(3L, group);
+        Report report = report(100L, customerUserWithId(1L), group, Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        ReportDetailDto result = reportService.get(attendant, 100L);
+
+        assertEquals(100L, result.id());
     }
 
     @Test
     void getThrowsInvalidCredentialsWhenAttendantRequestsReportInOtherGroup() {
-        // TODO: Write test
+        User attendant = attendantUserWithId(3L, attendantGroup(21L, "Stockholm"));
+        Report report = report(100L, customerUserWithId(1L), attendantGroup(20L, "Goteborg"), Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        assertThrows(
+            InvalidCredentialsException.class,
+            () -> reportService.get(attendant, 100L)
+        );
     }
 
     @Test
     void getThrowsNotFoundWhenReportDoesNotExist() {
-        // TODO: Write test
+        when(reportRepository.findById(100L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> reportService.get(adminUserWithId(1L), 100L));
     }
 
     @Test
     void updateAllowsCustomerToCancelNewReport() {
-        // TODO: Write test
+        User customer = customerUserWithId(1L);
+        Report report = report(100L, customer, attendantGroup(20L, "Goteborg"), Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        ReportDetailDto result = reportService.update(customer, Status.CANCELLED, 100L);
+
+        assertEquals(Status.CANCELLED, result.status());
+        assertEquals(Status.CANCELLED, report.getStatus());
     }
 
     @Test
     void updateAllowsCustomerToCancelAssignedReport() {
-        // TODO: Write test
+        User customer = customerUserWithId(1L);
+        Report report = report(100L, customer, attendantGroup(20L, "Goteborg"), Status.ASSIGNED);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        ReportDetailDto result = reportService.update(customer, Status.CANCELLED, 100L);
+
+        assertEquals(Status.CANCELLED, result.status());
     }
 
     @Test
     void updateThrowsInvalidCredentialsWhenCustomerSetsResolved() {
-        // TODO: Write test
+        User customer = customerUserWithId(1L);
+        Report report = report(100L, customer, attendantGroup(20L, "Goteborg"), Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        assertThrows(
+            InvalidCredentialsException.class,
+            () -> reportService.update(customer, Status.RESOLVED, 100L)
+        );
     }
 
     @Test
     void updateThrowsInvalidCredentialsWhenCustomerUpdatesOtherUsersReport() {
-        // TODO: Write test
-    }
+        Report report = report(100L, customerUserWithId(1L), attendantGroup(20L, "Goteborg"), Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
 
+        assertThrows(
+            InvalidCredentialsException.class,
+            () -> reportService.update(customerUserWithId(2L), Status.CANCELLED, 100L)
+        );
+    }
 
     @Test
     void updateAllowsAdminToSetAnyStatus() {
-        // TODO: Write test
-    }
+        Report report = report(100L, customerUserWithId(1L), attendantGroup(20L, "Goteborg"), Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
 
+        ReportDetailDto result = reportService.update(adminUserWithId(2L), Status.RESOLVED, 100L);
+
+        assertEquals(Status.RESOLVED, result.status());
+        assertEquals(Status.RESOLVED, report.getStatus());
+    }
 
     @Test
     void updateAllowsAttendantToAssignNewReportToSelf() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User attendant = attendantUserWithId(3L, group);
+        Report report = report(100L, customerUserWithId(1L), group, Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        ReportDetailDto result = reportService.update(attendant, Status.ASSIGNED, 100L);
+
+        assertEquals(Status.ASSIGNED, result.status());
+        assertEquals(3L, result.assignedToId());
+        assertSame(attendant, report.getAssignedTo());
     }
 
     @Test
     void updateThrowsAlreadyAssignedWhenAttendantAssignsAlreadyAssignedReport() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User attendant = attendantUserWithId(3L, group);
+        Report report = report(100L, customerUserWithId(1L), group, Status.ASSIGNED);
+        report.setAssignedTo(attendant);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        assertThrows(
+            AlreadyAssignedException.class,
+            () -> reportService.update(attendant, Status.ASSIGNED, 100L)
+        );
     }
 
     @Test
     void updateThrowsAlreadyAssignedWhenReportAssignedToAnotherAttendant() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User attendant = attendantUserWithId(3L, group);
+        Report report = report(100L, customerUserWithId(1L), group, Status.ASSIGNED);
+        report.setAssignedTo(attendantUserWithId(4L, group));
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        assertThrows(
+            AlreadyAssignedException.class,
+            () -> reportService.update(attendant, Status.RESOLVED, 100L)
+        );
     }
 
     @Test
     void updateAllowsAttendantToUnassignOwnAssignedReport() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User attendant = attendantUserWithId(3L, group);
+        Report report = report(100L, customerUserWithId(1L), group, Status.ASSIGNED);
+        report.setAssignedTo(attendant);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        ReportDetailDto result = reportService.update(attendant, Status.NEW, 100L);
+
+        assertEquals(Status.NEW, result.status());
+        assertNull(result.assignedToId());
+        assertNull(report.getAssignedTo());
     }
 
     @Test
     void updateAllowsAttendantToResolveOwnAssignedReport() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User attendant = attendantUserWithId(3L, group);
+        Report report = report(100L, customerUserWithId(1L), group, Status.ASSIGNED);
+        report.setAssignedTo(attendant);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        ReportDetailDto result = reportService.update(attendant, Status.RESOLVED, 100L);
+
+        assertEquals(Status.RESOLVED, result.status());
     }
 
     @Test
     void updateThrowsInvalidCredentialsWhenAttendantResolvesUnassignedReport() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User attendant = attendantUserWithId(3L, group);
+        Report report = report(100L, customerUserWithId(1L), group, Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        assertThrows(
+            InvalidCredentialsException.class,
+            () -> reportService.update(attendant, Status.RESOLVED, 100L)
+        );
     }
 
     @Test
     void updateThrowsInvalidCredentialsWhenAttendantSetsCancelled() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User attendant = attendantUserWithId(3L, group);
+        Report report = report(100L, customerUserWithId(1L), group, Status.NEW);
+        when(reportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        assertThrows(
+            InvalidCredentialsException.class,
+            () -> reportService.update(attendant, Status.CANCELLED, 100L)
+        );
     }
 
     @Test
     void updateThrowsNotFoundWhenReportDoesNotExist() {
-        // TODO: Write test
+        when(reportRepository.findById(100L)).thenReturn(Optional.empty());
+
+        assertThrows(
+            NotFoundException.class,
+            () -> reportService.update(adminUserWithId(1L), Status.RESOLVED, 100L)
+        );
     }
 
     @Test
     void getAllUsesAdminFiltersForAdmin() {
-        // TODO: Write test
+        when(reportRepository.findByFilters(eq(Status.NEW), eq("abc"), any(Pageable.class)))
+            .thenReturn(Page.empty());
+
+        reportService.getAll(0, 10, "createdOn", "desc", "abc", adminUserWithId(1L), Status.NEW, null);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(reportRepository).findByFilters(eq(Status.NEW), eq("abc"), pageableCaptor.capture());
+        assertEquals(0, pageableCaptor.getValue().getPageNumber());
+        assertEquals(10, pageableCaptor.getValue().getPageSize());
+        assertEquals("createdOn: DESC", pageableCaptor.getValue().getSort().toString());
     }
 
     @Test
     void getAllUsesGroupFiltersForAttendant() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User attendant = attendantUserWithId(3L, group);
+        when(reportRepository.findByFiltersInGroup(eq(Status.ASSIGNED), isNull(), eq(group), eq("abc"), any(Pageable.class)))
+            .thenReturn(Page.empty());
+
+        reportService.getAll(0, 10, "id", "asc", "abc", attendant, Status.ASSIGNED, null);
+
+        verify(reportRepository).findByFiltersInGroup(eq(Status.ASSIGNED), isNull(), eq(group), eq("abc"), any(Pageable.class));
     }
 
     @Test
     void getAllUsesCreatedByFiltersForCustomer() {
-        // TODO: Write test
+        User customer = customerUserWithId(1L);
+        when(reportRepository.findByFiltersCreatedBy(eq(Status.NEW), eq(customer), eq("abc"), any(Pageable.class)))
+            .thenReturn(Page.empty());
+
+        reportService.getAll(0, 10, "id", "asc", "abc", customer, Status.NEW, null);
+
+        verify(reportRepository).findByFiltersCreatedBy(eq(Status.NEW), eq(customer), eq("abc"), any(Pageable.class));
     }
 
     @Test
     void getAllResolvesAssignedToFilterWhenProvided() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User attendant = attendantUserWithId(3L, group);
+        User assignedTo = attendantUserWithId(4L, group);
+        when(userRepository.findById(4L)).thenReturn(Optional.of(assignedTo));
+        when(reportRepository.findByFiltersInGroup(isNull(), eq(assignedTo), eq(group), isNull(), any(Pageable.class)))
+            .thenReturn(Page.empty());
+
+        reportService.getAll(0, 10, "id", "asc", null, attendant, null, new UserRequest(4L));
+
+        verify(reportRepository).findByFiltersInGroup(isNull(), eq(assignedTo), eq(group), isNull(), any(Pageable.class));
     }
 
     @Test
     void getAllThrowsNotFoundWhenAssignedToFilterUserDoesNotExist() {
-        // TODO: Write test
+        when(userRepository.findById(4L)).thenReturn(Optional.empty());
+
+        assertThrows(
+            NotFoundException.class,
+            () -> reportService.getAll(0, 10, "id", "asc", null, adminUserWithId(1L), null, new UserRequest(4L))
+        );
+        verify(reportRepository, never()).findByFilters(any(), any(), any());
     }
 
     @Test
     void getAllMapsReportsToDetailDtos() {
-        // TODO: Write test
+        AttendantGroup group = attendantGroup(20L, "Goteborg");
+        User assignee = attendantUserWithId(3L, group);
+        Report report = report(100L, customerUserWithId(1L), group, Status.ASSIGNED);
+        report.setAssignedTo(assignee);
+        when(reportRepository.findByFilters(isNull(), isNull(), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(List.of(report)));
+
+        Page<ReportDetailDto> result = reportService.getAll(0, 10, "id", "asc", null, adminUserWithId(2L), null, null);
+
+        assertEquals(1, result.getTotalElements());
+        ReportDetailDto dto = result.getContent().get(0);
+        assertEquals(100L, dto.id());
+        assertEquals("ABC123", dto.licensePlate());
+        assertEquals(ParkingViolationCategory.NO_PARKING_AREA, dto.category());
+        assertEquals(group, dto.attendantGroup());
+        assertEquals(3L, dto.assignedToId());
+        assertEquals(Status.ASSIGNED, dto.status());
     }
 
 }
+

--- a/backend/src/test/java/se/voizter/felparkering/api/testsupport/TestDataFactory.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/testsupport/TestDataFactory.java
@@ -38,6 +38,12 @@ public final class TestDataFactory {
         return user;
     }
 
+    public static User customerUserWithId(Long id) {
+        User user = customerUser();
+        user.setId(id);
+        return user;
+    }
+
     public static User adminUser() {
         User user = new User();
         user.setEmail("admin@example.com");
@@ -51,6 +57,12 @@ public final class TestDataFactory {
         user.setEmail(email);
         user.setPassword(password);
         user.setRole(Role.ADMIN);
+        return user;
+    }
+
+    public static User adminUserWithId(Long id) {
+        User user = adminUser();
+        user.setId(id);
         return user;
     }
 
@@ -70,8 +82,20 @@ public final class TestDataFactory {
         return user;
     }
 
+    public static User attendantUserWithId(Long id) {
+        User user = attendantUser();
+        user.setId(id);
+        return user;
+    }
+
     public static User attendantUser(AttendantGroup group) {
         User user = attendantUser();
+        user.setAttendantGroup(group);
+        return user;
+    }
+
+    public static User attendantUserWithId(Long id, AttendantGroup group) {
+        User user = attendantUserWithId(id);
         user.setAttendantGroup(group);
         return user;
     }
@@ -86,6 +110,12 @@ public final class TestDataFactory {
     public static AttendantGroup attendantGroup(String name) {
         AttendantGroup attendantGroup = attendantGroup();
         attendantGroup.setName(name);
+        return attendantGroup;
+    }
+
+    public static AttendantGroup attendantGroup(Long id, String name) {
+        AttendantGroup attendantGroup = attendantGroup(name);
+        attendantGroup.setId(id);
         return attendantGroup;
     }
 
@@ -117,6 +147,16 @@ public final class TestDataFactory {
         return address;
     }
 
+    public static Address address(Long id, String street, List<String> houseNumbers, String city) {
+        Address address = address(street, houseNumbers, city);
+        address.setId(id);
+        return address;
+    }
+
+    public static Address address(Long id, String street, String houseNumber, String city) {
+        return address(id, street, List.of(houseNumber), city);
+    }
+
     // Reports
     public static Report report() {
         Report report = new Report();
@@ -132,6 +172,15 @@ public final class TestDataFactory {
     public static Report report(Address address) {
         Report report = report();
         report.setAddress(address);
+        return report;
+    }
+
+    public static Report report(Long id, User createdBy, AttendantGroup group, Status status) {
+        Report report = report();
+        report.setId(id);
+        report.setCreatedBy(createdBy);
+        report.setAttendantGroup(group);
+        report.setStatus(status);
         return report;
     }
 
@@ -220,6 +269,17 @@ public final class TestDataFactory {
             "ABC123", 
             ParkingViolationCategory.NO_PARKING_AREA
         );
+    }
+
+    public static ReportRequest reportRequest(
+        Long id,
+        String street,
+        String houseNumber,
+        String city,
+        String licensePlate,
+        ParkingViolationCategory category
+    ) {
+        return new ReportRequest(id, street, houseNumber, city, licensePlate, category);
     }
 
     public static UpdateStatusRequest updateStatusRequest(Status status) {


### PR DESCRIPTION
## 🔗 Jira Issue

Closes: FA-11

---

## 🧾 Description

Denna PR lägger till och städar upp service layer-tester.

* Implementerat tester för `AddressService`
* Implementerat tester för `AuthService`
* Implementerat tester för `AdminService`
* Implementerat tester för `ReportService`
* Utökat `TestDataFactory` med återanvändbara helpers för users, addresses, attendant groups, reports och report requests

---

## 🔄 Type of change

* [ ] ✨ Feature
* [ ] 🐛 Bugfix
* [ ] ♻️ Refactor
* [x] 🧹 Chore

---

## 🧪 How has this been tested?

* [ ] Manuellt testad
* [x] Enhetstester körda
* [ ] Testad via API / UI

Beskriv kort:

* Kört hela backend-testsviten med `.\gradlew.bat test`
* Verifierat service-tester för auth, admin, address och report-flöden
* Verifierat att inga privata helper-metoder finns kvar i service-testklasserna

---

## 🧠 Notes / Things to review

* Extra fokus på `ReportServiceTests`, eftersom den täcker flest roll- och statusfall

---

## ✅ Checklist

* [x] Koden bygger
* [x] Tester passerar
* [x] PR kopplad till Jira issue
* [x] Ingen debug-kod kvar
* [x] Rimlig kodstruktur
