### PR TITLE
Fa 115 standardize api contracts

### DIFF
--- a/backend/docs/api-spec.yaml
+++ b/backend/docs/api-spec.yaml
@@ -695,26 +695,28 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AddressSuggestion'
+                $ref: '#/components/schemas/AddressSearchResponse'
               example:
-                - id: 101
-                  street: Södra vägen
-                  city: Stockholm
-                  houseNumber: "1"
-                - id: 101
-                  street: Södra vägen
-                  city: Stockholm
-                  houseNumber: "3"
+                data:
+                  - id: 101
+                    street: Södra vägen
+                    city: Stockholm
+                    houseNumber: "1"
+                  - id: 101
+                    street: Södra vägen
+                    city: Stockholm
+                    houseNumber: "3"
+                message: Addresses fetched successfully
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorUnauthorized'
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Missing or invalid token
+                error:
+                  code: UNAUTHORIZED
+                  message: Missing or invalid token
       deprecated: false
       security:
         - bearer: []
@@ -749,36 +751,42 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RouteResponse'
+                $ref: '#/components/schemas/RouteApiResponse'
               example:
-                type: FeatureCollection
-                features:
-                  - type: Feature
-                    properties:
-                      summary:
-                        distance: 1200.5
-                        duration: 320.2
-                    geometry:
-                      type: LineString
-                      coordinates:
-                        - [18.0686, 59.3293]
-                        - [18.0649, 59.3326]
+                data:
+                  type: FeatureCollection
+                  features:
+                    - type: Feature
+                      properties:
+                        summary:
+                          distance: 1200.5
+                          duration: 320.2
+                      geometry:
+                        type: LineString
+                        coordinates:
+                          - [18.0686, 59.3293]
+                          - [18.0649, 59.3326]
+                message: Route fetched successfully
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorUnauthorized'
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Missing or invalid token
+                error:
+                  code: UNAUTHORIZED
+                  message: Missing or invalid token
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorAccessDenied'
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Access Denied
+                error:
+                  code: ACCESS_DENIED
+                  message: Access Denied
       deprecated: false
       security:
         - bearer: []
@@ -1402,6 +1410,26 @@ components:
         street: Södra vägen
         city: Stockholm
         houseNumber: "1"
+    AddressSearchResponse:
+      title: AddressSearchResponse
+      required:
+        - data
+        - message
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AddressSuggestion'
+        message:
+          type: string
+      example:
+        data:
+          - id: 101
+            street: Södra vägen
+            city: Stockholm
+            houseNumber: "1"
+        message: Addresses fetched successfully
     RouteRequest:
       title: RouteRequest
       required:
@@ -1458,6 +1486,32 @@ components:
               coordinates:
                 - [18.0686, 59.3293]
                 - [18.0649, 59.3326]
+    RouteApiResponse:
+      title: RouteApiResponse
+      required:
+        - data
+        - message
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/RouteResponse'
+        message:
+          type: string
+      example:
+        data:
+          type: FeatureCollection
+          features:
+            - type: Feature
+              properties:
+                summary:
+                  distance: 1200.5
+                  duration: 320.2
+              geometry:
+                type: LineString
+                coordinates:
+                  - [18.0686, 59.3293]
+                  - [18.0649, 59.3326]
+        message: Route fetched successfully
     Report:
       title: Report
       required:

--- a/backend/docs/api-spec.yaml
+++ b/backend/docs/api-spec.yaml
@@ -1144,7 +1144,7 @@ components:
         items:
           type: array
           items:
-            $ref: '#/components/schemas/Report'
+            $ref: '#/components/schemas/ReportDetailDto'
         page:
           type: integer
           format: int32
@@ -1209,7 +1209,7 @@ components:
       type: object
       properties:
         data:
-          $ref: '#/components/schemas/Report'
+          $ref: '#/components/schemas/ReportDetailDto'
         message:
           type: string
       example:
@@ -1234,8 +1234,8 @@ components:
           updatedOn: '2025-06-17T14:22:00Z'
           status: NEW
         message: Report fetched successfully
-    AttendantGroup:
-      title: AttendantGroup
+    AttendantGroupDto:
+      title: AttendantGroupDto
       required:
         - id
         - name
@@ -1249,8 +1249,8 @@ components:
       example:
         id: 1
         name: Stockholm Södra
-    Address:
-      title: Address
+    AddressDto:
+      title: AddressDto
       required:
         - id
         - longitude
@@ -1415,8 +1415,8 @@ components:
                   - [18.0686, 59.3293]
                   - [18.0649, 59.3326]
         message: Route fetched successfully
-    Report:
-      title: Report
+    ReportDetailDto:
+      title: ReportDetailDto
       required:
         - id
         - address
@@ -1433,13 +1433,13 @@ components:
           type: integer
           format: int64
         address:
-          $ref: '#/components/schemas/Address'
+          $ref: '#/components/schemas/AddressDto'
         licensePlate:
           type: string
         category:
           type: string
         attendantGroup:
-          $ref: '#/components/schemas/AttendantGroup'
+          $ref: '#/components/schemas/AttendantGroupDto'
         assignedToId:
           type: integer
           format: int64
@@ -1492,7 +1492,7 @@ components:
             - ATTENDANT
             - CUSTOMER
         attendantGroup:
-          $ref: '#/components/schemas/AttendantGroup'
+          $ref: '#/components/schemas/AttendantGroupDto'
       example:
         email: vakt@example.com
         password: secret123

--- a/backend/docs/api-spec.yaml
+++ b/backend/docs/api-spec.yaml
@@ -225,10 +225,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReportCreatedResponse'
+                $ref: '#/components/schemas/ReportResponse'
               example:
-                message: Report created successfully
-                report:
+                data:
                   id: 12
                   address:
                     id: 101
@@ -248,42 +247,42 @@ paths:
                   createdOn: '2025-06-17T14:22:00Z'
                   updatedOn: '2025-06-17T14:22:00Z'
                   status: NEW
+                message: Report created successfully
         '400':
           description: Bad Request
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorMissingCredentials'
-                  - example:
-                      error: Missing credentials
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationErrorResponse'
+                  - $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Missing credentials
+                errors:
+                  - field: licensePlate
+                    message: License plate is required
         '401':
           description: Unauthorized
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorUnauthorized'
-                  - example:
-                      error: Missing or invalid token
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Missing or invalid token
+                error:
+                  code: UNAUTHORIZED
+                  message: Missing or invalid token
         '403':
           description: Forbidden
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorAccessDenied'
-                  - example:
-                      error: You do not have permission to create a report
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: You do not have permission to create a report
+                error:
+                  code: ACCESS_DENIED
+                  message: You do not have permission to get all reports
       deprecated: false
       security:
         - bearer: []
@@ -325,7 +324,8 @@ paths:
           in: query
           required: false
           schema:
-            type: string
+            type: integer
+            format: int64
             default: createdOn
         - name: sortDir
           in: query
@@ -364,56 +364,56 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PagedReportResponse'
+                $ref: '#/components/schemas/PagedReportsResponse'
               example:
-                items:
-                  - id: 12
-                    address:
-                      id: 101
-                      street: Södra vägen
-                      houseNumbers:
-                        - "1"
-                      city: Stockholm
-                      latitude: 59.33
-                      longitude: 18.06
-                      distanceFromCity: 120
-                    licensePlate: ABC123
-                    category: NO_PARKING_AREA
-                    attendantGroup:
-                      id: 1
-                      name: Stockholm Södra
-                    assignedToId: 7
-                    createdOn: '2025-06-17T14:22:00Z'
-                    updatedOn: '2025-06-17T14:22:00Z'
-                    status: NEW
-                page: 0
-                size: 10
-                totalElements: 1
-                totalPages: 1
+                data:
+                  items:
+                    - id: 12
+                      address:
+                        id: 101
+                        street: Södra vägen
+                        houseNumbers:
+                          - "1"
+                        city: Stockholm
+                        latitude: 59.33
+                        longitude: 18.06
+                        distanceFromCity: 120
+                      licensePlate: ABC123
+                      category: NO_PARKING_AREA
+                      attendantGroup:
+                        id: 1
+                        name: Stockholm Södra
+                      assignedToId: 7
+                      createdOn: '2025-06-17T14:22:00Z'
+                      updatedOn: '2025-06-17T14:22:00Z'
+                      status: NEW
+                  page: 0
+                  size: 10
+                  totalElements: 1
+                  totalPages: 1
+                message: Reports fetched successfully
         '401':
           description: Unauthorized
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorUnauthorized'
-                  - example:
-                      error: Missing or invalid token
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Missing or invalid token
+                error:
+                  code: UNAUTHORIZED
+                  message: Missing or invalid token
         '403':
           description: Forbidden
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorAccessDenied'
-                  - example:
-                      error: You do not have permission to get all reports
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: You do not have permission to get all reports
+                error:
+                  code: ACCESS_DENIED
+                  message: You do not have permission to get all reports
       deprecated: false
       security:
         - bearer: []
@@ -455,84 +455,62 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/Report'
-                  - example:
-                      id: 12
-                      address:
-                        id: 101
-                        street: Södra vägen
-                        houseNumbers:
-                          - "1"
-                        city: Stad
-                        latitude: 59.3293
-                        longitude: 18.0686
-                        distanceFromCity: 120
-                      licensePlate: ABC123
-                      category: BLOCKERAR_UTFART
-                      attendantGroup:
-                        id: 1
-                        name: Stockholm Södra
-                      assignedToId: 7
-                      createdOn: '2025-06-17T14:22:00Z'
-                      updatedOn: '2025-06-17T14:22:00Z'
-                      status: NEW
+                $ref: '#/components/schemas/ReportResponse'
               example:
-                id: 12
-                address:
-                  id: 101
-                  street: Södra vägen
-                  houseNumbers:
-                    - "1"
-                  city: Stad
-                  latitude: 59.3293
-                  longitude: 18.0686
-                  distanceFromCity: 120
-                licensePlate: ABC123
-                category: BLOCKERAR_UTFART
-                attendantGroup:
-                  id: 1
-                  name: Stockholm Södra
-                assignedToId: 7
-                createdOn: '2025-06-17T14:22:00Z'
-                updatedOn: '2025-06-17T14:22:00Z'
-                status: NEW
+                data:
+                  id: 12
+                  address:
+                    id: 101
+                    street: Södra vägen
+                    houseNumbers:
+                      - "1"
+                    city: Stad
+                    latitude: 59.3293
+                    longitude: 18.0686
+                    distanceFromCity: 120
+                  licensePlate: ABC123
+                  category: NO_PARKING_AREA
+                  attendantGroup:
+                    id: 1
+                    name: Stockholm Södra
+                  assignedToId: 7
+                  createdOn: '2025-06-17T14:22:00Z'
+                  updatedOn: '2025-06-17T14:22:00Z'
+                  status: NEW
+                message: Report fetched successfully
         '401':
           description: Unauthorized
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorUnauthorized'
-                  - example:
-                      error: Missing or invalid token
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Missing or invalid token
+                error:
+                  code: UNAUTHORIZED
+                  message: Missing or invalid token
         '403':
           description: Forbidden
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorAccessDenied'
-                  - example:
-                      error: You do not have permission to get a report
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: You do not have permission to get a report
+                error:
+                  code: ACCESS_DENIED
+                  message: You do not have permission to get all reports
         '404':
           description: Not Found
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorNotFound'
-                  - example:
-                      error: Report not found
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Report not found
+                error:
+                  code: NOT_FOUND
+                  message: Report not found
       deprecated: false
       security:
         - bearer: []
@@ -592,10 +570,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReportUpdatedResponse'
+                $ref: '#/components/schemas/ReportResponse'
               example:
-                message: Report updated successfully
-                report:
+                data:
                   id: 12
                   address:
                     id: 101
@@ -614,20 +591,23 @@ paths:
                   assignedToId: null
                   createdOn: '2025-06-17T14:22:00Z'
                   updatedOn: '2025-06-17T14:22:00Z'
-                  status: NEW
+                  status: RESOLVED
+                message: Report updated successfully
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/ErrorBadRequest'
+                  - $ref: '#/components/schemas/ErrorResponse'
                   - $ref: '#/components/schemas/ValidationErrorResponse'
               examples:
                 invalidStatus:
                   summary: Invalid status value
                   value:
-                    error: Invalid request parameter or value
+                    error:
+                      code: BAD_REQUEST
+                      message: Invalid request parameter or value
                 missingStatus:
                   summary: Missing status
                   value:
@@ -640,36 +620,33 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorAccessDenied'
-                  - example:
-                      error: You do not have permission to update a report
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: You do not have permission to update a report
+                error:
+                  code: ACCESS_DENIED
+                  message: You do not have permission to get all reports
         '404':
           description: Not Found
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorNotFound'
-                  - example:
-                      error: Report not found
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Report not found
+                error:
+                  code: NOT_FOUND
+                  message: Report not found
         '409':
           description: Conflict
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorConflict'
-                  - example:
-                      error: Report is already assigned to a different user
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Report is already assigned to a different user
+                error:
+                  code: CONFLICT
+                  message: Report is already assigned to a different user
       deprecated: false
       security:
         - bearer: []
@@ -841,9 +818,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorBadRequest'
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Invalid request parameter or value
+                error:
+                  code: BAD_REQUEST
+                  message: Invalid request parameter or value
         '401':
           description: Unauthorized
           headers: {}
@@ -1137,46 +1116,6 @@ components:
       example:
         code: BAD_REQUEST
         message: Bad request
-    ErrorBadRequest:
-      title: ErrorBadRequest
-      required:
-        - error
-      type: object
-      properties:
-        error:
-          type: string
-      example:
-        error: Invalid request parameter or value
-    ErrorMissingCredentials:
-      title: ErrorMissingCredentials
-      required:
-        - error
-      type: object
-      properties:
-        error:
-          type: string
-      example:
-        error: Missing credentials
-    ErrorNotFound:
-      title: ErrorNotFound
-      required:
-        - error
-      type: object
-      properties:
-        error:
-          type: string
-      example:
-        error: User not found
-    ErrorConflict:
-      title: ErrorConflict
-      required:
-        - error
-      type: object
-      properties:
-        error:
-          type: string
-      example:
-        error: User already exists
     RegisterResponse:
       title: RegisterResponse
       required:
@@ -1243,20 +1182,38 @@ components:
         size: 10
         totalElements: 1
         totalPages: 1
-    ReportCreatedResponse:
-      title: ReportCreatedResponse
+    PagedReportsResponse:
+      title: PagedReportsResponse
       required:
+        - data
         - message
-        - report
       type: object
       properties:
+        data:
+          $ref: '#/components/schemas/PagedReportResponse'
         message:
           type: string
-        report:
-          $ref: '#/components/schemas/Report'
       example:
-        message: Report created successfully
-        report:
+        data:
+          items: []
+          page: 0
+          size: 10
+          totalElements: 0
+          totalPages: 0
+        message: Reports fetched successfully
+    ReportResponse:
+      title: ReportResponse
+      required:
+        - data
+        - message
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/Report'
+        message:
+          type: string
+      example:
+        data:
           id: 12
           address:
             id: 101
@@ -1276,41 +1233,7 @@ components:
           createdOn: '2025-06-17T14:22:00Z'
           updatedOn: '2025-06-17T14:22:00Z'
           status: NEW
-    ReportUpdatedResponse:
-      title: ReportUpdatedResponse
-      required:
-        - message
-        - report
-      type: object
-      properties:
-        message:
-          type: string
-        updatedOn:
-          type: string
-        report:
-          $ref: '#/components/schemas/Report'
-      example:
-        message: Report updated successfully
-        report:
-          id: 12
-          address:
-            id: 101
-            longitude: 18.06
-            latitude: 59.33
-            street: Södra vägen
-            houseNumbers:
-              - "1"
-            city: Stockholm
-            distanceFromCity: 120
-          licensePlate: ABC123
-          category: NO_PARKING_AREA
-          attendantGroup:
-            id: 1
-            name: Stockholm Södra
-          assignedToId: null
-          createdOn: '2025-06-17T14:22:00Z'
-          updatedOn: '2025-06-17T14:22:00Z'
-          status: NEW
+        message: Report fetched successfully
     AttendantGroup:
       title: AttendantGroup
       required:
@@ -1326,26 +1249,6 @@ components:
       example:
         id: 1
         name: Stockholm Södra
-    ErrorUnauthorized:
-      title: ErrorUnauthorized
-      required:
-        - error
-      type: object
-      properties:
-        error:
-          type: string
-      example:
-        error: Missing or invalid token
-    ErrorAccessDenied:
-      title: ErrorAccessDenied
-      required:
-        - error
-      type: object
-      properties:
-        error:
-          type: string
-      example:
-        error: You do not have permission to create a report
     Address:
       title: Address
       required:

--- a/backend/docs/api-spec.yaml
+++ b/backend/docs/api-spec.yaml
@@ -36,8 +36,8 @@ paths:
                   type: string
                   example: abc123
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Created
           headers: {}
           content:
             application/json:
@@ -122,8 +122,8 @@ paths:
                   type: string
                   example: abc123
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Created
           headers: {}
           content:
             application/json:
@@ -815,15 +815,18 @@ paths:
                 id: 1
                 name: Stockholm Södra
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Created
           headers: {}
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdminUserCreatedResponse'
               example:
-                user: 'User with id: 7 was created.'
+                data:
+                  id: 7
+                  role: ATTENDANT
+                message: User was created successfully
         '400':
           description: Bad Request
           headers: {}
@@ -839,24 +842,22 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorUnauthorized'
-                  - example:
-                      error: Missing or invalid token
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Missing or invalid token
+                error:
+                  code: UNAUTHORIZED
+                  message: Missing or invalid token
         '403':
           description: Forbidden
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorAccessDenied'
-                  - example:
-                      error: You do not have permission to create a user
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: You do not have permission to create a user
+                error:
+                  code: ACCESS_DENIED
+                  message: Access Denied
       deprecated: false
       security:
         - bearer: []
@@ -889,35 +890,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/AdminUsersResponse'
               example:
-                users:
+                data:
                   - id: 1
                     role: CUSTOMER
                   - id: 7
                     role: ATTENDANT
+                message: Users fetched successfully
         '401':
           description: Unauthorized
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorUnauthorized'
-                  - example:
-                      error: Missing or invalid token
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Missing or invalid token
+                error:
+                  code: UNAUTHORIZED
+                  message: Missing or invalid token
         '403':
           description: Forbidden
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorAccessDenied'
-                  - example:
-                      error: You do not have permission to get all users
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: You do not have permission to get all users
+                error:
+                  code: ACCESS_DENIED
+                  message: Access Denied
       deprecated: false
       security:
         - bearer: []
@@ -951,7 +951,8 @@ paths:
           required: true
           style: simple
           schema:
-            type: string
+            type: integer
+            format: int64
       responses:
         '200':
           description: OK
@@ -959,48 +960,44 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DeletedResponse'
-                  - example:
-                      message: User was successfully deleted
+                $ref: '#/components/schemas/DeletedUserResponse'
               example:
-                message: User was successfully deleted
+                data:
+                  id: 7
+                message: User deleted successfully
         '401':
           description: Unauthorized
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorUnauthorized'
-                  - example:
-                      error: Missing or invalid token
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Missing or invalid token
+                error:
+                  code: UNAUTHORIZED
+                  message: Missing or invalid token
         '403':
           description: Forbidden
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorAccessDenied'
-                  - example:
-                      error: You do not have permission to delete a user
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: You do not have permission to delete a user
+                error:
+                  code: ACCESS_DENIED
+                  message: Access Denied
         '404':
           description: Not Found
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorNotFound'
-                  - example:
-                      error: User not found
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: User not found
+                error:
+                  code: NOT_FOUND
+                  message: User not found
       deprecated: false
       security:
         - bearer: []
@@ -1034,37 +1031,36 @@ paths:
               schema:
                 $ref: '#/components/schemas/AdminAttendantGroupsResponse'
               example:
-                attendantGroups:
+                data:
                   - name: Stockholm Södra
                     attendants:
                       - id: 7
                         role: ATTENDANT
                   - name: Stockholm Norra
                     attendants: []
+                message: Attendant groups fetched successfully
         '401':
           description: Unauthorized
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorUnauthorized'
-                  - example:
-                      error: Missing or invalid token
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Missing or invalid token
+                error:
+                  code: UNAUTHORIZED
+                  message: Missing or invalid token
         '403':
           description: Forbidden
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorAccessDenied'
-                  - example:
-                      error: You do not have permission to get all attendant groups
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: You do not have permission to get all attendant groups
+                error:
+                  code: ACCESS_DENIED
+                  message: Access Denied
       deprecated: false
       security:
         - bearer: []
@@ -1153,16 +1149,6 @@ components:
           type: string
       example:
         error: Missing credentials
-    ErrorInvalidCredentials:
-      title: ErrorInvalidCredentials
-      required:
-        - error
-      type: object
-      properties:
-        error:
-          type: string
-      example:
-        error: Invalid credentials
     ErrorNotFound:
       title: ErrorNotFound
       required:
@@ -1560,13 +1546,19 @@ components:
     AdminUserCreatedResponse:
       title: AdminUserCreatedResponse
       required:
-        - user
+        - data
+        - message
       type: object
       properties:
-        user:
+        data:
+          $ref: '#/components/schemas/UserAdminDetailDto'
+        message:
           type: string
       example:
-        user: 'User with id: 7 was created.'
+        data:
+          id: 7
+          role: ATTENDANT
+        message: User was created successfully
     UserAdminDetailDto:
       title: UserAdminDetailDto
       required:
@@ -1589,19 +1581,23 @@ components:
     AdminUsersResponse:
       title: AdminUsersResponse
       required:
-        - users
+        - data
+        - message
       type: object
       properties:
-        users:
+        data:
           type: array
           items:
             $ref: '#/components/schemas/UserAdminDetailDto'
+        message:
+          type: string
       example:
-        users:
+        data:
           - id: 1
             role: CUSTOMER
           - id: 7
             role: ATTENDANT
+        message: Users fetched successfully
     AttendantGroupDetailDto:
       title: AttendantGroupDetailDto
       required:
@@ -1624,19 +1620,44 @@ components:
     AdminAttendantGroupsResponse:
       title: AdminAttendantGroupsResponse
       required:
-        - attendantGroups
+        - data
+        - message
       type: object
       properties:
-        attendantGroups:
+        data:
           type: array
           items:
             $ref: '#/components/schemas/AttendantGroupDetailDto'
+        message:
+          type: string
       example:
-        attendantGroups:
+        data:
           - name: Stockholm Södra
             attendants:
               - id: 7
                 role: ATTENDANT
+        message: Attendant groups fetched successfully
+    DeletedUserResponse:
+      title: DeletedUserResponse
+      required:
+        - data
+        - message
+      type: object
+      properties:
+        data:
+          type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+        message:
+          type: string
+      example:
+        data:
+          id: 7
+        message: User deleted successfully
     UserDetailDto:
       title: UserDetailDto
       required:
@@ -1648,16 +1669,6 @@ components:
           description: JWT token där `sub` claim innehåller användarens id.
       example:
           token: eyJhbGciOiJIUzI1NiIsInR5cCI6...
-    DeletedResponse:
-      title: DeletedResponse
-      required:
-        - message
-      type: object
-      properties:
-        message:
-          type: string
-      example:
-        message: User was successfully deleted
   securitySchemes:
     bearer:
       type: http

--- a/backend/docs/api-spec.yaml
+++ b/backend/docs/api-spec.yaml
@@ -44,7 +44,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/LoginResponse'
               example:
-                user:
+                data:
                   token: eyJhbGciOiJIUzI1NiIsInR5cCI6...
                 message: User logged in successfully
         '400':
@@ -55,7 +55,7 @@ paths:
               schema:
                 oneOf:
                   - $ref: '#/components/schemas/ValidationErrorResponse'
-                  - $ref: '#/components/schemas/ErrorMissingCredentials'
+                  - $ref: '#/components/schemas/ErrorResponse'
               examples:
                 validationError:
                   summary: Validation error
@@ -66,31 +66,31 @@ paths:
                 missingCredentials:
                   summary: Missing credentials
                   value:
-                    error: Missing credentials
+                    error:
+                      code: BAD_REQUEST
+                      message: Missing credentials
         '401':
           description: Unauthorized
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorInvalidCredentials'
-                  - example:
-                      error: Invalid credentials
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: Invalid credentials
+                error:
+                  code: INVALID_CREDENTIALS
+                  message: Invalid credentials
         '404':
           description: Not Found
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorNotFound'
-                  - example:
-                      error: User not found
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: User not found
+                error:
+                  code: NOT_FOUND
+                  message: User not found
       deprecated: false
       security: []
   /register:
@@ -130,7 +130,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegisterResponse'
               example:
-                  user: 
+                  data: 
                     token: eyJhbGciOiJIUzI1NiIsInR5cCI6...
                   message: User registered successfully
         '400':
@@ -152,24 +152,26 @@ paths:
                 missingCredentials: 
                   summary: Missing credentials
                   value:
-                    error: Missing credentials
+                    error:
+                      code: BAD_REQUEST
+                      message: Missing credentials
                 passwordMismatch:
                   summary: Password and confirmation does not match
                   value:
-                    error: Password and confirmation does not match
+                    error:
+                      code: BAD_REQUEST
+                      message: Password and confirmation does not match
         '409':
           description: Conflict
           headers: {}
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ErrorConflict'
-                  - example:
-                      message: 
-                      error: User already exists
+                $ref: '#/components/schemas/ErrorResponse'
               example:
-                error: User already exists
+                error:
+                  code: CONFLICT
+                  message: User already exists
       deprecated: false
   /reports:
     post:
@@ -1071,16 +1073,16 @@ components:
     LoginResponse:
       title: LoginResponse
       required:
-        - user
+        - data
         - message
       type: object
       properties:
-        user:
+        data:
           $ref: '#/components/schemas/UserDetailDto'
         message:
           type: string
       example:
-        user:
+        data:
           token: eyJhbGciOiJIUzI1NiIsInR5cCI6...
         message: User logged in successfully
     ValidationErrorResponse:
@@ -1112,9 +1114,25 @@ components:
         - error
       properties:
         error:
+          $ref: '#/components/schemas/ErrorBody'
+      example:
+        error:
+          code: BAD_REQUEST
+          message: Bad request
+    ErrorBody:
+      title: ErrorBody
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
           type: string
       example:
-        error: Bad request
+        code: BAD_REQUEST
+        message: Bad request
     ErrorBadRequest:
       title: ErrorBadRequest
       required:
@@ -1168,16 +1186,16 @@ components:
     RegisterResponse:
       title: RegisterResponse
       required:
-        - user
+        - data
         - message
       type: object
       properties:
-        user:
+        data:
           $ref: '#/components/schemas/UserDetailDto'
         message:
           type: string
       example:
-        user:
+        data:
           token: eyJhbGciOiJIUzI1NiIsInR5cCI6...
         message: User registered successfully
     PagedReportResponse:

--- a/backend/docs/api-spec.yaml
+++ b/backend/docs/api-spec.yaml
@@ -36,8 +36,8 @@ paths:
                   type: string
                   example: abc123
       responses:
-        '201':
-          description: Created
+        '200':
+          description: OK
           headers: {}
           content:
             application/json:
@@ -1594,6 +1594,17 @@ components:
               - id: 7
                 role: ATTENDANT
         message: Attendant groups fetched successfully
+    DeletedUserDto:
+      title: DeletedUserDto
+      required:
+        - id
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+      example:
+        id: 7
     DeletedUserResponse:
       title: DeletedUserResponse
       required:
@@ -1602,13 +1613,7 @@ components:
       type: object
       properties:
         data:
-          type: object
-          required:
-            - id
-          properties:
-            id:
-              type: integer
-              format: int64
+          $ref: '#/components/schemas/DeletedUserDto'
         message:
           type: string
       example:

--- a/backend/src/main/java/se/voizter/felparkering/api/configuration/SecurityConfig.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/configuration/SecurityConfig.java
@@ -21,7 +21,12 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jakarta.servlet.http.HttpServletResponse;
+import se.voizter.felparkering.api.dto.ErrorBody;
+import se.voizter.felparkering.api.dto.ErrorResponse;
+import se.voizter.felparkering.api.enums.Message;
 import se.voizter.felparkering.api.security.JwtFilter;
 import se.voizter.felparkering.api.security.JwtProvider;
 
@@ -34,9 +39,11 @@ import se.voizter.felparkering.api.security.JwtProvider;
 public class SecurityConfig {
     
     private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
 
-    public SecurityConfig(JwtProvider jwtProvider) {
+    public SecurityConfig(JwtProvider jwtProvider, ObjectMapper objectMapper) {
         this.jwtProvider = jwtProvider;
+        this.objectMapper = objectMapper;
     }
 
     /**
@@ -66,14 +73,20 @@ public class SecurityConfig {
         .addFilterAfter(new JwtFilter(jwtProvider), SecurityContextHolderFilter.class)
         .exceptionHandling(e -> e
             .authenticationEntryPoint((req, res, ex) -> {
-                res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                res.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                res.getWriter().write("{\"error\":\"Missing or invalid token\"}");
+                writeError(
+                    res,
+                    HttpServletResponse.SC_UNAUTHORIZED,
+                    Message.UNAUTHORIZED.name(),
+                    Message.UNAUTHORIZED.toString()
+                );
             })
             .accessDeniedHandler((req, res, ex) -> {
-                res.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                res.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                res.getWriter().write("{\"error\":\"Access Denied\"}");
+                writeError(
+                    res, 
+                    HttpServletResponse.SC_FORBIDDEN, 
+                    Message.ACCESS_DENIED.name(),
+                     Message.ACCESS_DENIED.toString()
+                );
             })
         );
         return http.build();
@@ -106,4 +119,18 @@ public class SecurityConfig {
             return source;
     }
 
+    private void writeError(
+        HttpServletResponse response,
+        int status,
+        String code,
+        String message
+    ) throws java.io.IOException {
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        objectMapper.writeValue(
+            response.getOutputStream(),
+            new ErrorResponse(new ErrorBody(code, message))
+        );
+    }
 }

--- a/backend/src/main/java/se/voizter/felparkering/api/controller/AddressController.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/controller/AddressController.java
@@ -3,6 +3,7 @@ package se.voizter.felparkering.api.controller;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,8 +11,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import se.voizter.felparkering.api.dto.AddressSuggestionDto;
+import se.voizter.felparkering.api.dto.ApiResponse;
 import se.voizter.felparkering.api.dto.RouteRequest;
+import se.voizter.felparkering.api.enums.Message;
 import se.voizter.felparkering.api.service.AddressService;
 
 @RestController
@@ -24,12 +28,26 @@ public class AddressController {
     }
 
     @GetMapping("/search")
-    public List<AddressSuggestionDto> search(@RequestParam String query) {
-        return addressService.getAddresses(query);
+    public ResponseEntity<ApiResponse<List<AddressSuggestionDto>>> search(@RequestParam String query) {
+        List<AddressSuggestionDto> addresses = addressService.getAddresses(query);
+
+        return ResponseEntity.ok(
+            new ApiResponse<>(
+                addresses,
+                Message.ADDRESSES_FETCHED.toString()
+            )
+        );
     }
 
     @PostMapping("/route")
-    public Map<?,?> getRoute(@RequestBody RouteRequest request) {
-        return addressService.getRoute(request.start(), request.end());
+    public ResponseEntity<ApiResponse<Map<?, ?>>> getRoute(@Valid @RequestBody RouteRequest request) {
+        Map<?, ?> route = addressService.getRoute(request.start(), request.end());
+
+        return ResponseEntity.ok(
+            new ApiResponse<>(
+                route,
+                Message.ROUTE_FETCHED.toString()
+            )
+        );
     }
 }

--- a/backend/src/main/java/se/voizter/felparkering/api/controller/AdminController.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/controller/AdminController.java
@@ -1,8 +1,8 @@
 package se.voizter.felparkering.api.controller;
 
 import java.util.List;
-import java.util.Map;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,12 +13,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import se.voizter.felparkering.api.dto.ApiResponse;
 import se.voizter.felparkering.api.dto.AttendantGroupDetailDto;
+import se.voizter.felparkering.api.dto.DeletedUserResponse;
 import se.voizter.felparkering.api.dto.UserAdminDetailDto;
-import se.voizter.felparkering.api.model.AttendantGroup;
+import se.voizter.felparkering.api.enums.Message;
 import se.voizter.felparkering.api.model.User;
-import se.voizter.felparkering.api.repository.AttendantGroupRepository;
-import se.voizter.felparkering.api.repository.UserRepository;
 import se.voizter.felparkering.api.service.AdminService;
 
 @RestController
@@ -32,26 +32,47 @@ public class AdminController {
     }
 
     @GetMapping("/users")
-    public ResponseEntity<?> allUsers() {
+    public ResponseEntity<ApiResponse<List<UserAdminDetailDto>>> allUsers() {
         List<UserAdminDetailDto> users = adminService.getAllUsers();
-        return ResponseEntity.ok(Map.of("users", users));
+        return ResponseEntity.ok(
+            new ApiResponse<>(
+                users, 
+                Message.ADMIN_USERS_FETCHED.toString()
+            )
+        );
     }
 
     @PostMapping("/users")
-    public ResponseEntity<?> createAttendant(@Valid @RequestBody User attendant) {
+    public ResponseEntity<ApiResponse<UserAdminDetailDto>> createAttendant(@Valid @RequestBody User attendant) {
         UserAdminDetailDto user = adminService.createAttendant(attendant);
-        return ResponseEntity.ok(Map.of("user", "User with id: " + user.id() + " was created."));
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(new ApiResponse<>(
+                    user, 
+                    Message.USER_CREATED.toString()
+                )
+            );
     }
 
     @DeleteMapping("/users/{id}")
-    public ResponseEntity<?> deleteUser(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<DeletedUserResponse>> deleteUser(@PathVariable Long id) {
         adminService.deleteUser(id);
-        return ResponseEntity.ok(Map.of("message", "User with id: " + id + " was deleted."));
+        return ResponseEntity.ok(
+            new ApiResponse<>(
+                new DeletedUserResponse(id),
+                Message.USER_DELETED.toString()
+            )
+        );
     }
     
     @GetMapping("/attendants")
-    public ResponseEntity<?> allAttendantGroups() {
+    public ResponseEntity<ApiResponse<List<AttendantGroupDetailDto>>> allAttendantGroups() {
         List<AttendantGroupDetailDto> groups = adminService.getAllAttendantGroups();
-        return ResponseEntity.ok(Map.of("attendantGroups", groups));
+        return ResponseEntity.ok(
+            new ApiResponse<>(
+                groups,
+                Message.ADMIN_GROUPS_FETCHED.toString()
+            )
+        );
     }
 }

--- a/backend/src/main/java/se/voizter/felparkering/api/controller/AdminController.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/controller/AdminController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import se.voizter.felparkering.api.dto.ApiResponse;
 import se.voizter.felparkering.api.dto.AttendantGroupDetailDto;
-import se.voizter.felparkering.api.dto.DeletedUserResponse;
+import se.voizter.felparkering.api.dto.DeletedUserDto;
 import se.voizter.felparkering.api.dto.UserAdminDetailDto;
 import se.voizter.felparkering.api.enums.Message;
 import se.voizter.felparkering.api.model.User;
@@ -55,11 +55,11 @@ public class AdminController {
     }
 
     @DeleteMapping("/users/{id}")
-    public ResponseEntity<ApiResponse<DeletedUserResponse>> deleteUser(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<DeletedUserDto>> deleteUser(@PathVariable Long id) {
         adminService.deleteUser(id);
         return ResponseEntity.ok(
             new ApiResponse<>(
-                new DeletedUserResponse(id),
+                new DeletedUserDto(id),
                 Message.USER_DELETED.toString()
             )
         );

--- a/backend/src/main/java/se/voizter/felparkering/api/controller/AuthController.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/controller/AuthController.java
@@ -1,13 +1,12 @@
 package se.voizter.felparkering.api.controller;
 
-import java.util.Map;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import se.voizter.felparkering.api.dto.ApiResponse;
 import se.voizter.felparkering.api.dto.LoginRequest;
 import se.voizter.felparkering.api.dto.RegisterRequest;
 import se.voizter.felparkering.api.dto.UserDetailDto;
@@ -24,14 +23,14 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
+    public ResponseEntity<ApiResponse<UserDetailDto>> login(@Valid @RequestBody LoginRequest request) {
         UserDetailDto user = authService.login(request);
-        return ResponseEntity.ok(Map.of("user", user, "message", Message.LOGIN.toString()));
+        return ResponseEntity.ok(new ApiResponse<>(user, Message.LOGIN.toString()));
     }
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest request) {
+    public ResponseEntity<ApiResponse<UserDetailDto>> register(@Valid @RequestBody RegisterRequest request) {
         UserDetailDto user = authService.register(request);
-        return ResponseEntity.ok(Map.of("user", user, "message", Message.REGISTER.toString()));
+        return ResponseEntity.ok(new ApiResponse<>(user, Message.REGISTER.toString()));
     }
 }

--- a/backend/src/main/java/se/voizter/felparkering/api/controller/AuthController.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/controller/AuthController.java
@@ -25,12 +25,22 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<UserDetailDto>> login(@Valid @RequestBody LoginRequest request) {
         UserDetailDto user = authService.login(request);
-        return ResponseEntity.ok(new ApiResponse<>(user, Message.LOGIN.toString()));
+        return ResponseEntity.ok(
+            new ApiResponse<>(
+                user, 
+                Message.LOGIN.toString()
+            )
+        );
     }
 
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<UserDetailDto>> register(@Valid @RequestBody RegisterRequest request) {
         UserDetailDto user = authService.register(request);
-        return ResponseEntity.ok(new ApiResponse<>(user, Message.REGISTER.toString()));
+        return ResponseEntity.ok(
+            new ApiResponse<>(
+                user, 
+                Message.REGISTER.toString()
+            )
+        );
     }
 }

--- a/backend/src/main/java/se/voizter/felparkering/api/controller/AuthController.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/controller/AuthController.java
@@ -1,5 +1,7 @@
 package se.voizter.felparkering.api.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,7 +38,7 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<UserDetailDto>> register(@Valid @RequestBody RegisterRequest request) {
         UserDetailDto user = authService.register(request);
-        return ResponseEntity.ok(
+        return ResponseEntity.status(HttpStatus.CREATED).body(
             new ApiResponse<>(
                 user, 
                 Message.REGISTER.toString()

--- a/backend/src/main/java/se/voizter/felparkering/api/controller/ReportController.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/controller/ReportController.java
@@ -1,7 +1,5 @@
 package se.voizter.felparkering.api.controller;
 
-import java.util.Map;
-
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,11 +16,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import se.voizter.felparkering.api.dto.ApiResponse;
 import se.voizter.felparkering.api.dto.PagedReportResponse;
-import se.voizter.felparkering.api.dto.ReportCreatedResponse;
 import se.voizter.felparkering.api.dto.ReportDetailDto;
 import se.voizter.felparkering.api.dto.ReportRequest;
-import se.voizter.felparkering.api.dto.ReportUpdatedResponse;
 import se.voizter.felparkering.api.dto.UpdateStatusRequest;
 import se.voizter.felparkering.api.dto.UserRequest;
 import se.voizter.felparkering.api.model.User;
@@ -61,7 +58,7 @@ public class ReportController {
     }
 
     @GetMapping
-    public ResponseEntity<?> all(
+    public ResponseEntity<ApiResponse<PagedReportResponse>> all(
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "10") int size,
         @RequestParam(defaultValue = "createdOn") String sortBy,
@@ -71,35 +68,53 @@ public class ReportController {
         @RequestParam(required = false) UserRequest assignedToId
         ) {
         Page<ReportDetailDto> reports = reportService.getAll(page, size, sortBy, sortDir, search, currentUser(), status, assignedToId);
-        
         return ResponseEntity.ok(
-            new PagedReportResponse(
-                reports.getContent(), 
-                reports.getNumber(), 
-                reports.getSize(), 
-                reports.getTotalElements(), 
-                reports.getTotalPages()
+            new ApiResponse<>(
+                new PagedReportResponse(
+                    reports.getContent(), 
+                    reports.getNumber(), 
+                    reports.getSize(), 
+                    reports.getTotalElements(), 
+                    reports.getTotalPages()
+                ),
+                Message.REPORTS_FETCHED.toString()
             )
+            
         );
     }
 
     @PostMapping
-    public ResponseEntity<?> createReport(@Valid @RequestBody ReportRequest request) {
+    public ResponseEntity<ApiResponse<ReportDetailDto>> createReport(@Valid @RequestBody ReportRequest request) {
         ReportDetailDto report = reportService.create(currentUser(), request);
         return ResponseEntity
             .status(HttpStatus.CREATED)
-            .body(new ReportCreatedResponse(Message.REPORT_CREATED_SUCCESSFULLY.toString(), report));
+            .body(
+                new ApiResponse<>(
+                    report,
+                    Message.REPORT_CREATED_SUCCESSFULLY.toString()
+                )
+            );
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<?> one(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<ReportDetailDto>> one(@PathVariable Long id) {
         ReportDetailDto report = reportService.get(currentUser(), id);
-        return ResponseEntity.ok(report);
+        return ResponseEntity.ok(
+            new ApiResponse<>(
+                report,
+                Message.REPORT_FETCHED.toString()
+            )
+        );
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?> updateStatus(@Valid @RequestBody UpdateStatusRequest request, @PathVariable Long id) {
+    public ResponseEntity<ApiResponse<ReportDetailDto>> updateStatus(@Valid @RequestBody UpdateStatusRequest request, @PathVariable Long id) {
         ReportDetailDto report = reportService.update(currentUser(), request.status(), id);
-        return ResponseEntity.ok(new ReportUpdatedResponse(Message.REPORT_UPDATED_SUCCESSFULLY.toString(), report));
+        return ResponseEntity.ok(
+            new ApiResponse<>(
+                report,
+                Message.REPORT_UPDATED_SUCCESSFULLY.toString()
+            )
+        );
     }
 }

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/AddressDto.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/AddressDto.java
@@ -1,0 +1,31 @@
+package se.voizter.felparkering.api.dto;
+
+import java.util.List;
+
+import se.voizter.felparkering.api.model.Address;
+
+public record AddressDto(
+    Long id,
+    double longitude,
+    double latitude,
+    String street,
+    List<String> houseNumbers,
+    String city,
+    double distanceFromCity
+) {
+    public static AddressDto fromEntity(Address address) {
+        if (address == null) {
+            return null;
+        }
+
+        return new AddressDto(
+            address.getId(),
+            address.getLongitude(),
+            address.getLatitude(),
+            address.getStreet(), 
+            address.getHouseNumbers(),
+            address.getCity(),
+            address.getDistanceFromCity()
+        );
+    }
+}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/ApiResponse.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/ApiResponse.java
@@ -1,0 +1,6 @@
+package se.voizter.felparkering.api.dto;
+
+public record ApiResponse<T>(
+    T data,
+    String message
+) {}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/AttendantGroupDto.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/AttendantGroupDto.java
@@ -1,0 +1,19 @@
+package se.voizter.felparkering.api.dto;
+
+import se.voizter.felparkering.api.model.AttendantGroup;
+
+public record AttendantGroupDto(
+    Long id,
+    String name
+) {
+    public static AttendantGroupDto fromEntity(AttendantGroup group) {
+        if (group == null) {
+            return null;
+        }
+
+        return new AttendantGroupDto(
+            group.getId(),
+            group.getName()
+        );
+    }
+}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/DeletedUserDto.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/DeletedUserDto.java
@@ -1,0 +1,3 @@
+package se.voizter.felparkering.api.dto;
+
+public record DeletedUserDto(Long id) {}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/DeletedUserResponse.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/DeletedUserResponse.java
@@ -1,0 +1,3 @@
+package se.voizter.felparkering.api.dto;
+
+public record DeletedUserResponse(Long id) {}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/DeletedUserResponse.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/DeletedUserResponse.java
@@ -1,3 +1,0 @@
-package se.voizter.felparkering.api.dto;
-
-public record DeletedUserResponse(Long id) {}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/ErrorBody.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/ErrorBody.java
@@ -1,0 +1,6 @@
+package se.voizter.felparkering.api.dto;
+
+public record ErrorBody(
+    String code,
+    String message
+) {}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/ErrorResponse.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/ErrorResponse.java
@@ -1,0 +1,5 @@
+package se.voizter.felparkering.api.dto;
+
+public record ErrorResponse(
+    ErrorBody error
+) {}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/FieldErrorDto.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/FieldErrorDto.java
@@ -1,0 +1,6 @@
+package se.voizter.felparkering.api.dto;
+
+public record FieldErrorDto(
+    String field,
+    String message
+) {}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/LoginRequest.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/LoginRequest.java
@@ -3,7 +3,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record LoginRequest (
+public record LoginRequest(
     @NotBlank(message = "Email address is required")
     @Email(message = "Invalid email address")
     String email,

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/RegisterRequest.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/RegisterRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record RegisterRequest (
+public record RegisterRequest(
     @NotBlank(message = "Email address is required")
     @Email(message = "Invalid email address")
     String email,

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/ReportCreatedResponse.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/ReportCreatedResponse.java
@@ -1,6 +1,0 @@
-package se.voizter.felparkering.api.dto;
-
-public record ReportCreatedResponse(
-    String message,
-    ReportDetailDto report
-) {}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/ReportDetailDto.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/ReportDetailDto.java
@@ -4,15 +4,13 @@ import java.time.Instant;
 
 import se.voizter.felparkering.api.enums.ParkingViolationCategory;
 import se.voizter.felparkering.api.enums.Status;
-import se.voizter.felparkering.api.model.Address;
-import se.voizter.felparkering.api.model.AttendantGroup;
 
 public record ReportDetailDto(
     Long id,
-    Address address,
+    AddressDto address,
     String licensePlate,
     ParkingViolationCategory category,
-    AttendantGroup attendantGroup,
+    AttendantGroupDto attendantGroup,
     Long assignedToId,
     Instant createdOn,
     Instant updatedOn,

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/UserDetailDto.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/UserDetailDto.java
@@ -1,5 +1,5 @@
 package se.voizter.felparkering.api.dto;
 
-public record UserDetailDto (
+public record UserDetailDto(
     String token
  ) {}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/UserRequest.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/UserRequest.java
@@ -2,7 +2,7 @@ package se.voizter.felparkering.api.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record UserRequest (
+public record UserRequest(
     @NotBlank(message = "Id is required")
     Long id
 ) {}

--- a/backend/src/main/java/se/voizter/felparkering/api/dto/ValidationErrorResponse.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/dto/ValidationErrorResponse.java
@@ -1,0 +1,7 @@
+package se.voizter.felparkering.api.dto;
+
+import java.util.List;
+
+public record ValidationErrorResponse(
+    List<FieldErrorDto> errors
+){}

--- a/backend/src/main/java/se/voizter/felparkering/api/enums/Message.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/enums/Message.java
@@ -3,6 +3,8 @@ package se.voizter.felparkering.api.enums;
 public enum Message {
     LOGIN("User logged in successfully"),
     REGISTER("User registered successfully"),
+    UNAUTHORIZED("Missing or invalid token"),
+    ACCESS_DENIED("Access Denied"),
     MISSING_CREDENTIALS("Missing credentials"),
     PASSWORD_MISMATCH("Password and confirmation does not match"),
     USER_EXISTS("User already exists"),

--- a/backend/src/main/java/se/voizter/felparkering/api/enums/Message.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/enums/Message.java
@@ -10,6 +10,8 @@ public enum Message {
     USER_EXISTS("User already exists"),
     INVALID_CREDENTIALS("Invalid credentials"),
     USER_NOT_FOUND("User not found"),
+    USER_DELETED("User deleted successfully"),
+    USER_CREATED("User was created successfully"),
     REPORT_NOT_FOUND("Report not found"),
     ADDRESS_NOT_FOUND("Address not found"),
     ATTENDANT_GROUP_NOT_FOUND("Attendant group not found"),
@@ -17,6 +19,8 @@ public enum Message {
     REPORT_NO_PERMISSION("You do not have permission to get all reports"),
     REPORT_ALREADY_ASSIGNED("Report is already assigned to a different user"),
     REPORT_UPDATED_SUCCESSFULLY("Report updated successfully"),
+    ADMIN_USERS_FETCHED("Users fetched successfully"),
+    ADMIN_GROUPS_FETCHED("Attendant groups fetched successfully"),
     ;
 
     private final String prettyName;

--- a/backend/src/main/java/se/voizter/felparkering/api/enums/Message.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/enums/Message.java
@@ -19,6 +19,8 @@ public enum Message {
     REPORT_NO_PERMISSION("You do not have permission to get all reports"),
     REPORT_ALREADY_ASSIGNED("Report is already assigned to a different user"),
     REPORT_UPDATED_SUCCESSFULLY("Report updated successfully"),
+    ADDRESSES_FETCHED("Addresses fetched successfully"),
+    ROUTE_FETCHED("Route fetched successfully"),
     ADMIN_USERS_FETCHED("Users fetched successfully"),
     ADMIN_GROUPS_FETCHED("Attendant groups fetched successfully"),
     ;

--- a/backend/src/main/java/se/voizter/felparkering/api/enums/Message.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/enums/Message.java
@@ -21,6 +21,8 @@ public enum Message {
     REPORT_UPDATED_SUCCESSFULLY("Report updated successfully"),
     ADDRESSES_FETCHED("Addresses fetched successfully"),
     ROUTE_FETCHED("Route fetched successfully"),
+    REPORTS_FETCHED("Reports fetched successfully"),
+    REPORT_FETCHED("Report fetched successfully"),
     ADMIN_USERS_FETCHED("Users fetched successfully"),
     ADMIN_GROUPS_FETCHED("Attendant groups fetched successfully"),
     ;

--- a/backend/src/main/java/se/voizter/felparkering/api/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/exception/GlobalExceptionHandler.java
@@ -17,6 +17,10 @@ import se.voizter.felparkering.api.exception.exceptions.MissingCredentialsExcept
 import se.voizter.felparkering.api.exception.exceptions.NotFoundException;
 import se.voizter.felparkering.api.exception.exceptions.PasswordMismatchException;
 import se.voizter.felparkering.api.exception.exceptions.UserConflictException;
+import se.voizter.felparkering.api.dto.ErrorBody;
+import se.voizter.felparkering.api.dto.ErrorResponse;
+import se.voizter.felparkering.api.dto.FieldErrorDto;
+import se.voizter.felparkering.api.dto.ValidationErrorResponse;
 import se.voizter.felparkering.api.enums.Message;
 
 @RestControllerAdvice
@@ -24,80 +28,78 @@ public class GlobalExceptionHandler {
     
     @ExceptionHandler(MethodArgumentNotValidException.class) 
     public ResponseEntity<?> handleValidationErrors(MethodArgumentNotValidException exception) {
-        List<Map<String,String>> errors = exception.getBindingResult()
+        List<FieldErrorDto> errors = exception.getBindingResult()
             .getFieldErrors()
             .stream()
-            .map(error -> Map.of(
-                "field", error.getField(),
-                "message", error.getDefaultMessage()
+            .map(error -> new FieldErrorDto(
+                error.getField(),
+                error.getDefaultMessage()
             ))
             .toList();
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("errors", errors));
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(new ValidationErrorResponse(errors));
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<?> handleEnumMismatch(MethodArgumentTypeMismatchException exception) {
+    public ResponseEntity<ErrorResponse> handleEnumMismatch(MethodArgumentTypeMismatchException exception) {
         Class<?> requiredType = exception.getRequiredType();
 
         if (requiredType != null && requiredType.isEnum()) {
             String enumValues = String.join(", ", Arrays.stream(requiredType.getEnumConstants()).map(Object::toString).toArray(String[]::new));
 
             String message = String.format("Invalid value '%s' for enum %s. Allowed values are: [%s]", exception.getValue(), requiredType.getSimpleName(), enumValues);
-
-            return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("error", message));
+            
+            return error(HttpStatus.BAD_REQUEST, "BAD_REQUEST", message);
         }
 
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(Map.of("error", "Invalid request parameter or value"));
+        return error(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "Invalid request parameter or value");
     }
 
     @ExceptionHandler(PasswordMismatchException.class)
-    public ResponseEntity<?> handlePasswordMismatch(PasswordMismatchException exception) {
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(Map.of("error", exception.getMessage()));
+    public ResponseEntity<ErrorResponse> handlePasswordMismatch(PasswordMismatchException exception) {
+        return error(HttpStatus.BAD_REQUEST, "BAD_REQUEST", exception.getMessage());
     }
 
     @ExceptionHandler(UserConflictException.class)
-    public ResponseEntity<?> handleUserConflict(UserConflictException exception) {
-        return ResponseEntity
-            .status(HttpStatus.CONFLICT)
-            .body(Map.of("error", exception.getMessage()));
+    public ResponseEntity<ErrorResponse> handleUserConflict(UserConflictException exception) {
+        return error(HttpStatus.CONFLICT, "CONFLICT", exception.getMessage());
     }
 
     @ExceptionHandler(MissingCredentialsException.class)
-    public ResponseEntity<?> handleMissingCredentials(MissingCredentialsException exception) {
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(Map.of("error", exception.getMessage()));
+    public ResponseEntity<ErrorResponse> handleMissingCredentials(MissingCredentialsException exception) {
+        return error(HttpStatus.BAD_REQUEST, "BAD_REQUEST", exception.getMessage());
     }
 
     @ExceptionHandler(InvalidCredentialsException.class)
-    public ResponseEntity<?> handleInvalidCredentials(InvalidCredentialsException exception) {
-        HttpStatus status = Message.INVALID_CREDENTIALS.toString().equals(exception.getMessage())
+    public ResponseEntity<ErrorResponse> handleInvalidCredentials(InvalidCredentialsException exception) {
+        boolean isLoginFailure = Message.INVALID_CREDENTIALS.toString().equals(exception.getMessage());
+
+        HttpStatus status = isLoginFailure
             ? HttpStatus.UNAUTHORIZED
             : HttpStatus.FORBIDDEN;
 
-        return ResponseEntity
-            .status(status)
-            .body(Map.of("error", exception.getMessage()));
+        String code = isLoginFailure
+            ? "INVALID_CREDENTIALS"
+            : "ACCESS_DENIED";
+
+        return error(status, code, exception.getMessage());
     }
 
     @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<?> handleNotFound(NotFoundException exception) {
-        return ResponseEntity
-            .status(HttpStatus.NOT_FOUND)
-            .body(Map.of("error", exception.getMessage()));
+    public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException exception) {
+        return error(HttpStatus.NOT_FOUND, "NOT_FOUND", exception.getMessage());
     }
 
     @ExceptionHandler(AlreadyAssignedException.class)
     public ResponseEntity<?> handleAlreadyAssigned(AlreadyAssignedException exception) {
+        return error(HttpStatus.CONFLICT, "CONFLICT", exception.getMessage());
+    }
+
+    private ResponseEntity<ErrorResponse> error(HttpStatus status, String code, String message) {
         return ResponseEntity
-            .status(HttpStatus.CONFLICT)
-            .body(Map.of("error", exception.getMessage()));
+            .status(status)
+            .body(new ErrorResponse(new ErrorBody(code, message)));
     }
 }

--- a/backend/src/main/java/se/voizter/felparkering/api/service/ReportService.java
+++ b/backend/src/main/java/se/voizter/felparkering/api/service/ReportService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 
 import jakarta.annotation.Nullable;
 import jakarta.transaction.Transactional;
+import se.voizter.felparkering.api.dto.AddressDto;
+import se.voizter.felparkering.api.dto.AttendantGroupDto;
 import se.voizter.felparkering.api.dto.ReportDetailDto;
 import se.voizter.felparkering.api.dto.ReportRequest;
 import se.voizter.felparkering.api.dto.UserRequest;
@@ -185,10 +187,10 @@ public class ReportService {
         Long assigneeId = report.getAssignedTo() != null ? report.getAssignedTo().getId() : null;
         return new ReportDetailDto(
             report.getId(),
-            report.getAddress(),
+            AddressDto.fromEntity(report.getAddress()),
             report.getLicensePlate(),
             report.getCategory(),
-            report.getAttendantGroup(),
+            AttendantGroupDto.fromEntity(report.getAttendantGroup()),
             assigneeId,
             report.getCreatedOn(),
             report.getUpdatedOn(),

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/AddressControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/AddressControllerTests.java
@@ -33,6 +33,7 @@ import se.voizter.felparkering.api.dto.RouteRequest;
 import se.voizter.felparkering.api.enums.Message;
 import se.voizter.felparkering.api.security.JwtProvider;
 import se.voizter.felparkering.api.service.AddressService;
+import se.voizter.felparkering.api.testsupport.OpenApiValidation;
 import se.voizter.felparkering.api.testsupport.TestDataFactory;
 
 @WebMvcTest(AddressController.class)
@@ -52,13 +53,15 @@ public class AddressControllerTests {
 
         mockMvc.perform(get("/addresses/search")
                 .param("query", "test")
+                .header("Authorization", "Bearer test-token")
                 .with(authentication(auth(1L, "ROLE_CUSTOMER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data[0].id").value(1))
             .andExpect(jsonPath("$.data[0].street").value("Testgatan"))
             .andExpect(jsonPath("$.data[0].city").value("Teststad"))
             .andExpect(jsonPath("$.data[0].houseNumber").value("2"))
-            .andExpect(jsonPath("$.message").value(Message.ADDRESSES_FETCHED.toString()));
+            .andExpect(jsonPath("$.message").value(Message.ADDRESSES_FETCHED.toString()))
+            .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }
 
     @Test
@@ -91,11 +94,13 @@ public class AddressControllerTests {
 
         mockMvc.perform(post("/addresses/route")
                 .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer test-token")
                 .content(objectMapper.writeValueAsString(request))
             .with(authentication(auth(1L, "ROLE_ATTENDANT"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.type").value("FeatureCollection"))
-            .andExpect(jsonPath("$.message").value(Message.ROUTE_FETCHED.toString()));
+            .andExpect(jsonPath("$.message").value(Message.ROUTE_FETCHED.toString()))
+            .andExpect(OpenApiValidation.matchesOpenApiSpec());
 
         verify(addressService).getRoute(
             argThat(start -> Arrays.equals(start, request.start())),

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/AddressControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/AddressControllerTests.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import se.voizter.felparkering.api.configuration.SecurityConfig;
 import se.voizter.felparkering.api.dto.AddressSuggestionDto;
 import se.voizter.felparkering.api.dto.RouteRequest;
+import se.voizter.felparkering.api.enums.Message;
 import se.voizter.felparkering.api.security.JwtProvider;
 import se.voizter.felparkering.api.service.AddressService;
 import se.voizter.felparkering.api.testsupport.TestDataFactory;
@@ -53,10 +54,11 @@ public class AddressControllerTests {
                 .param("query", "test")
                 .with(authentication(auth(1L, "ROLE_CUSTOMER"))))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$[0].id").value(1))
-            .andExpect(jsonPath("$[0].street").value("Testgatan"))
-            .andExpect(jsonPath("$[0].city").value("Teststad"))
-            .andExpect(jsonPath("$[0].houseNumber").value("2"));
+            .andExpect(jsonPath("$.data[0].id").value(1))
+            .andExpect(jsonPath("$.data[0].street").value("Testgatan"))
+            .andExpect(jsonPath("$.data[0].city").value("Teststad"))
+            .andExpect(jsonPath("$.data[0].houseNumber").value("2"))
+            .andExpect(jsonPath("$.message").value(Message.ADDRESSES_FETCHED.toString()));
     }
 
     @Test
@@ -90,9 +92,10 @@ public class AddressControllerTests {
         mockMvc.perform(post("/addresses/route")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
-                .with(authentication(auth(1L, "ROLE_ATTENDANT"))))
+            .with(authentication(auth(1L, "ROLE_ATTENDANT"))))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.type").value("FeatureCollection"));
+            .andExpect(jsonPath("$.data.type").value("FeatureCollection"))
+            .andExpect(jsonPath("$.message").value(Message.ROUTE_FETCHED.toString()));
 
         verify(addressService).getRoute(
             argThat(start -> Arrays.equals(start, request.start())),

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/AdminControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/AdminControllerTests.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import se.voizter.felparkering.api.configuration.SecurityConfig;
 import se.voizter.felparkering.api.dto.AttendantGroupDetailDto;
 import se.voizter.felparkering.api.dto.UserAdminDetailDto;
+import se.voizter.felparkering.api.enums.Message;
 import se.voizter.felparkering.api.enums.Role;
 import se.voizter.felparkering.api.model.User;
 import se.voizter.felparkering.api.security.JwtProvider;
@@ -49,10 +50,11 @@ public class AdminControllerTests {
             .thenReturn(List.of(new UserAdminDetailDto(1L, Role.ADMIN)));
 
         mockMvc.perform(get("/admin/users")
-                .with(authentication(auth(1L, "ROLE_ADMIN"))))
+            .with(authentication(auth(1L, "ROLE_ADMIN"))))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.users[0].id").value(1))
-            .andExpect(jsonPath("$.users[0].role").value("ADMIN"));
+            .andExpect(jsonPath("$.data[0].id").value(1))
+            .andExpect(jsonPath("$.data[0].role").value("ADMIN"))
+            .andExpect(jsonPath("$.message").value(Message.ADMIN_USERS_FETCHED.toString()));
     }
 
     @Test
@@ -75,10 +77,12 @@ public class AdminControllerTests {
 
         mockMvc.perform(post("/admin/users")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(TestDataFactory.attendantUser()))
-                .with(authentication(auth(1L, "ROLE_ADMIN"))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.user").value("User with id: 7 was created."));
+            .content(objectMapper.writeValueAsString(TestDataFactory.attendantUser()))
+            .with(authentication(auth(1L, "ROLE_ADMIN"))))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.id").value(7))
+            .andExpect(jsonPath("$.data.role").value("ATTENDANT"))
+            .andExpect(jsonPath("$.message").value(Message.USER_CREATED.toString()));
     }
 
     @Test
@@ -88,9 +92,9 @@ public class AdminControllerTests {
 
         mockMvc.perform(post("/admin/users")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(TestDataFactory.attendantUser()))
-                .with(authentication(auth(1L, "ROLE_ADMIN"))))
-            .andExpect(status().isOk());
+            .content(objectMapper.writeValueAsString(TestDataFactory.attendantUser()))
+            .with(authentication(auth(1L, "ROLE_ADMIN"))))
+            .andExpect(status().isCreated());
 
         verify(adminService).createAttendant(any(User.class));
     }
@@ -98,9 +102,10 @@ public class AdminControllerTests {
     @Test
     void deleteUserReturnsOkForAdmin() throws Exception {
         mockMvc.perform(delete("/admin/users/7")
-                .with(authentication(auth(1L, "ROLE_ADMIN"))))
+            .with(authentication(auth(1L, "ROLE_ADMIN"))))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.message").value("User with id: 7 was deleted."));
+            .andExpect(jsonPath("$.data.id").value(7))
+            .andExpect(jsonPath("$.message").value(Message.USER_DELETED.toString()));
     }
 
     @Test
@@ -118,9 +123,10 @@ public class AdminControllerTests {
             .thenReturn(List.of(new AttendantGroupDetailDto("Testgruppen", List.of())));
 
         mockMvc.perform(get("/admin/attendants")
-                .with(authentication(auth(1L, "ROLE_ADMIN"))))
+            .with(authentication(auth(1L, "ROLE_ADMIN"))))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.attendantGroups[0].name").value("Testgruppen"));
+            .andExpect(jsonPath("$.data[0].name").value("Testgruppen"))
+            .andExpect(jsonPath("$.message").value(Message.ADMIN_GROUPS_FETCHED.toString()));
     }
 
     private static UsernamePasswordAuthenticationToken auth(Long id, String role) {

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/AdminControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/AdminControllerTests.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,7 @@ import se.voizter.felparkering.api.enums.Role;
 import se.voizter.felparkering.api.model.User;
 import se.voizter.felparkering.api.security.JwtProvider;
 import se.voizter.felparkering.api.service.AdminService;
+import se.voizter.felparkering.api.testsupport.OpenApiValidation;
 import se.voizter.felparkering.api.testsupport.TestDataFactory;
 
 @WebMvcTest(AdminController.class)
@@ -50,11 +52,13 @@ public class AdminControllerTests {
             .thenReturn(List.of(new UserAdminDetailDto(1L, Role.ADMIN)));
 
         mockMvc.perform(get("/admin/users")
+            .header("Authorization", "Bearer test-token")
             .with(authentication(auth(1L, "ROLE_ADMIN"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data[0].id").value(1))
             .andExpect(jsonPath("$.data[0].role").value("ADMIN"))
-            .andExpect(jsonPath("$.message").value(Message.ADMIN_USERS_FETCHED.toString()));
+            .andExpect(jsonPath("$.message").value(Message.ADMIN_USERS_FETCHED.toString()))
+            .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }
 
     @Test
@@ -77,12 +81,14 @@ public class AdminControllerTests {
 
         mockMvc.perform(post("/admin/users")
                 .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(TestDataFactory.attendantUser()))
+            .header("Authorization", "Bearer test-token")
+            .content(objectMapper.writeValueAsString(adminUserCreateRequest()))
             .with(authentication(auth(1L, "ROLE_ADMIN"))))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.data.id").value(7))
             .andExpect(jsonPath("$.data.role").value("ATTENDANT"))
-            .andExpect(jsonPath("$.message").value(Message.USER_CREATED.toString()));
+            .andExpect(jsonPath("$.message").value(Message.USER_CREATED.toString()))
+            .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }
 
     @Test
@@ -92,7 +98,7 @@ public class AdminControllerTests {
 
         mockMvc.perform(post("/admin/users")
                 .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(TestDataFactory.attendantUser()))
+            .content(objectMapper.writeValueAsString(adminUserCreateRequest()))
             .with(authentication(auth(1L, "ROLE_ADMIN"))))
             .andExpect(status().isCreated());
 
@@ -102,10 +108,12 @@ public class AdminControllerTests {
     @Test
     void deleteUserReturnsOkForAdmin() throws Exception {
         mockMvc.perform(delete("/admin/users/7")
+            .header("Authorization", "Bearer test-token")
             .with(authentication(auth(1L, "ROLE_ADMIN"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.id").value(7))
-            .andExpect(jsonPath("$.message").value(Message.USER_DELETED.toString()));
+            .andExpect(jsonPath("$.message").value(Message.USER_DELETED.toString()))
+            .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }
 
     @Test
@@ -123,10 +131,12 @@ public class AdminControllerTests {
             .thenReturn(List.of(new AttendantGroupDetailDto("Testgruppen", List.of())));
 
         mockMvc.perform(get("/admin/attendants")
+            .header("Authorization", "Bearer test-token")
             .with(authentication(auth(1L, "ROLE_ADMIN"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data[0].name").value("Testgruppen"))
-            .andExpect(jsonPath("$.message").value(Message.ADMIN_GROUPS_FETCHED.toString()));
+            .andExpect(jsonPath("$.message").value(Message.ADMIN_GROUPS_FETCHED.toString()))
+            .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }
 
     private static UsernamePasswordAuthenticationToken auth(Long id, String role) {
@@ -134,6 +144,18 @@ public class AdminControllerTests {
             id,
             null,
             List.of(new SimpleGrantedAuthority(role))
+        );
+    }
+
+    private static Map<String, Object> adminUserCreateRequest() {
+        return Map.of(
+            "email", "vakt@example.com",
+            "password", "password123",
+            "role", "ATTENDANT",
+            "attendantGroup", Map.of(
+                "id", 1L,
+                "name", "Stockholm Sodra"
+            )
         );
     }
 }

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/AuthControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/AuthControllerTests.java
@@ -109,14 +109,14 @@ public class AuthControllerTests {
     }
 
     @Test
-    void registerReturnsOkWithUserAndMessage() throws Exception {
+    void registerReturnsCreatedWithUserAndMessage() throws Exception {
         when(authService.register(any(RegisterRequest.class)))
             .thenReturn(new UserDetailDto("jwt-token"));
 
         mockMvc.perform(post("/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(TestDataFactory.registerRequest())))
-            .andExpect(status().isOk())
+            .andExpect(status().isCreated())
             .andExpect(jsonPath("$.data.token").value("jwt-token"))
             .andExpect(jsonPath("$.message").value(Message.REGISTER.toString()))
             .andExpect(OpenApiValidation.matchesOpenApiSpec());

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/AuthControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/AuthControllerTests.java
@@ -49,7 +49,7 @@ public class AuthControllerTests {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(TestDataFactory.loginRequest())))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.user.token").value("jwt-token"))
+            .andExpect(jsonPath("$.data.token").value("jwt-token"))
             .andExpect(jsonPath("$.message").value(Message.LOGIN.toString()))
             .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }
@@ -117,7 +117,7 @@ public class AuthControllerTests {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(TestDataFactory.registerRequest())))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.user.token").value("jwt-token"))
+            .andExpect(jsonPath("$.data.token").value("jwt-token"))
             .andExpect(jsonPath("$.message").value(Message.REGISTER.toString()))
             .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/AuthControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/AuthControllerTests.java
@@ -93,7 +93,7 @@ public class AuthControllerTests {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(TestDataFactory.loginRequest())))
             .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.error").value(Message.USER_NOT_FOUND.toString()));
+            .andExpect(jsonPath("$.error.message").value(Message.USER_NOT_FOUND.toString()));
     }
 
     @Test
@@ -105,7 +105,7 @@ public class AuthControllerTests {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(TestDataFactory.loginRequest())))
             .andExpect(status().isUnauthorized())
-            .andExpect(jsonPath("$.error").value(Message.INVALID_CREDENTIALS.toString()));
+            .andExpect(jsonPath("$.error.message").value(Message.INVALID_CREDENTIALS.toString()));
     }
 
     @Test
@@ -161,7 +161,7 @@ public class AuthControllerTests {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(TestDataFactory.registerRequest())))
             .andExpect(status().isConflict())
-            .andExpect(jsonPath("$.error").value(Message.USER_EXISTS.toString()));
+            .andExpect(jsonPath("$.error.message").value(Message.USER_EXISTS.toString()));
     }
 
     @Test
@@ -173,6 +173,6 @@ public class AuthControllerTests {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(TestDataFactory.registerRequest())))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value(Message.PASSWORD_MISMATCH.toString()));
+            .andExpect(jsonPath("$.error.message").value(Message.PASSWORD_MISMATCH.toString()));
     }
 }

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/ReportControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/ReportControllerTests.java
@@ -163,7 +163,7 @@ public class ReportControllerTests {
                 .content(objectMapper.writeValueAsString(TestDataFactory.reportRequest()))
                 .with(authentication(auth(1L, "ROLE_ATTENDANT"))))
             .andExpect(status().isForbidden())
-            .andExpect(jsonPath("$.error").value(Message.REPORT_NO_PERMISSION.toString()));
+            .andExpect(jsonPath("$.error.message").value(Message.REPORT_NO_PERMISSION.toString()));
     }
 
     @Test
@@ -192,7 +192,7 @@ public class ReportControllerTests {
         mockMvc.perform(get("/reports/99")
                 .with(authentication(auth(1L, "ROLE_CUSTOMER"))))
             .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.error").value(Message.REPORT_NOT_FOUND.toString()));
+            .andExpect(jsonPath("$.error.message").value(Message.REPORT_NOT_FOUND.toString()));
     }
 
     @Test
@@ -206,7 +206,7 @@ public class ReportControllerTests {
         mockMvc.perform(get("/reports/12")
                 .with(authentication(auth(1L, "ROLE_CUSTOMER"))))
             .andExpect(status().isForbidden())
-            .andExpect(jsonPath("$.error").value(Message.REPORT_NO_PERMISSION.toString()));
+            .andExpect(jsonPath("$.error.message").value(Message.REPORT_NO_PERMISSION.toString()));
     }
 
     @Test
@@ -257,7 +257,7 @@ public class ReportControllerTests {
                 .content(objectMapper.writeValueAsString(TestDataFactory.updateStatusRequest(Status.ASSIGNED)))
                 .with(authentication(auth(1L, "ROLE_ATTENDANT"))))
             .andExpect(status().isConflict())
-            .andExpect(jsonPath("$.error").value(Message.REPORT_ALREADY_ASSIGNED.toString()));
+            .andExpect(jsonPath("$.error.message").value(Message.REPORT_ALREADY_ASSIGNED.toString()));
     }
 
     private static UsernamePasswordAuthenticationToken auth(Long id, String role) {

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/ReportControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/ReportControllerTests.java
@@ -70,7 +70,7 @@ public class ReportControllerTests {
         mockMvc.perform(get("/reports")
                 .with(authentication(auth(1L, "ROLE_CUSTOMER"))))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.items[0].id").value(12));
+            .andExpect(jsonPath("$.data.items[0].id").value(12));
     }
 
     @Test
@@ -117,8 +117,8 @@ public class ReportControllerTests {
                 .with(authentication(auth(1L, "ROLE_CUSTOMER"))))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.message").value("Report created successfully"))
-            .andExpect(jsonPath("$.report.id").value(12))
-            .andExpect(jsonPath("$.report.createdOn").exists())
+            .andExpect(jsonPath("$.data.id").value(12))
+            .andExpect(jsonPath("$.data.createdOn").exists())
             .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }
 
@@ -177,7 +177,7 @@ public class ReportControllerTests {
                 .header("Authorization", "Bearer test-token")
                 .with(authentication(auth(1L, "ROLE_CUSTOMER"))))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id").value(12))
+            .andExpect(jsonPath("$.data.id").value(12))
             .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }
 
@@ -223,8 +223,8 @@ public class ReportControllerTests {
                 .with(authentication(auth(1L, "ROLE_ADMIN"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.message").value("Report updated successfully"))
-            .andExpect(jsonPath("$.report.id").value(12))
-            .andExpect(jsonPath("$.report.status").value(Status.RESOLVED.toString()));
+            .andExpect(jsonPath("$.data.id").value(12))
+            .andExpect(jsonPath("$.data.status").value(Status.RESOLVED.toString()));
     }
 
     @Test

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/ReportControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/ReportControllerTests.java
@@ -70,9 +70,11 @@ public class ReportControllerTests {
             .thenReturn(new PageImpl<>(List.of(reportDetail(12L)), PageRequest.of(0, 10), 1));
 
         mockMvc.perform(get("/reports")
+                .header("Authorization", "Bearer test-token")
                 .with(authentication(auth(1L, "ROLE_CUSTOMER"))))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.items[0].id").value(12));
+            .andExpect(jsonPath("$.data.items[0].id").value(12))
+            .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }
 
     @Test
@@ -221,12 +223,14 @@ public class ReportControllerTests {
 
         mockMvc.perform(put("/reports/12")
                 .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer test-token")
                 .content(objectMapper.writeValueAsString(TestDataFactory.updateStatusRequest(Status.RESOLVED)))
                 .with(authentication(auth(1L, "ROLE_ADMIN"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.message").value("Report updated successfully"))
             .andExpect(jsonPath("$.data.id").value(12))
-            .andExpect(jsonPath("$.data.status").value(Status.RESOLVED.toString()));
+            .andExpect(jsonPath("$.data.status").value(Status.RESOLVED.toString()))
+            .andExpect(OpenApiValidation.matchesOpenApiSpec());
     }
 
     @Test

--- a/backend/src/test/java/se/voizter/felparkering/api/controller/ReportControllerTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/controller/ReportControllerTests.java
@@ -30,6 +30,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import se.voizter.felparkering.api.configuration.SecurityConfig;
+import se.voizter.felparkering.api.dto.AddressDto;
+import se.voizter.felparkering.api.dto.AttendantGroupDto;
 import se.voizter.felparkering.api.dto.ReportDetailDto;
 import se.voizter.felparkering.api.dto.ReportRequest;
 import se.voizter.felparkering.api.enums.Message;
@@ -277,10 +279,10 @@ public class ReportControllerTests {
         AttendantGroup group = TestDataFactory.attendantGroup(1L, "Testgruppen");
         return new ReportDetailDto(
             id,
-            address,
+            AddressDto.fromEntity(address),
             "ABC123",
             ParkingViolationCategory.NO_PARKING_AREA,
-            group,
+            AttendantGroupDto.fromEntity(group),
             null,
             Instant.parse("2026-04-30T10:00:00Z"),
             Instant.parse("2026-04-30T10:05:00Z"),

--- a/backend/src/test/java/se/voizter/felparkering/api/service/ReportServiceTests.java
+++ b/backend/src/test/java/se/voizter/felparkering/api/service/ReportServiceTests.java
@@ -82,10 +82,14 @@ public class ReportServiceTests {
             reportRequest(10L, "Kungsgatan", "15", "Goteborg", "abc123", ParkingViolationCategory.NO_PARKING_FEE_PAID)
         );
 
-        assertEquals(address, result.address());
+        assertEquals(address.getId(), result.address().id());
+        assertEquals(address.getStreet(), result.address().street());
+        assertEquals(address.getHouseNumbers(), result.address().houseNumbers());
+        assertEquals(address.getCity(), result.address().city());
         assertEquals("ABC123", result.licensePlate());
         assertEquals(ParkingViolationCategory.NO_PARKING_FEE_PAID, result.category());
-        assertEquals(group, result.attendantGroup());
+        assertEquals(group.getId(), result.attendantGroup().id());
+        assertEquals(group.getName(), result.attendantGroup().name());
         assertEquals(Status.NEW, result.status());
     }
 
@@ -517,7 +521,8 @@ public class ReportServiceTests {
         assertEquals(100L, dto.id());
         assertEquals("ABC123", dto.licensePlate());
         assertEquals(ParkingViolationCategory.NO_PARKING_AREA, dto.category());
-        assertEquals(group, dto.attendantGroup());
+        assertEquals(group.getId(), dto.attendantGroup().id());
+        assertEquals(group.getName(), dto.attendantGroup().name());
         assertEquals(3L, dto.assignedToId());
         assertEquals(Status.ASSIGNED, dto.status());
     }


### PR DESCRIPTION
## 🔗 Jira Issue

Closes: FA-115

---

## 🧾 Description

Denna PR standardiserar API-responses och uppdaterar OpenAPI-kontraktet så det matchar implementationen bättre.

* Lagt till gemensamma response DTOs för success- och error-format
* Standardiserat success responses till `{ data, message }`
* Standardiserat error responses till `{ error: { code, message } }`
* Behållit validation errors som `{ errors: [...] }`
* Uppdaterat controllers för Auth, Admin, Address och Report till standardiserade response-format
* Lagt till/uppdaterat DTOs för API-responses, t.ex. `ReportDetailDto`, `AddressDto`, `AttendantGroupDto`, `DeletedUserDto`
* Uppdaterat `ReportService` så API:t returnerar DTOs istället för JPA entities
* Uppdaterat `api-spec.yaml` endpoint för endpoint för att matcha nya response-format
* Uppdaterat OpenAPI schemas till DTO-baserade schemas istället för entity-baserade schemas
* Lagt till OpenAPI contract validation i controller-tester via `OpenApiValidation.matchesOpenApiSpec()`
* Säkerställt att CI kör backend-tester och Redocly-validering av `api-spec.yaml`

---

## 🔄 Type of change

* [ ] ✨ Feature
* [ ] 🐛 Bugfix
* [x] ♻️ Refactor
* [x] 🧹 Chore

---

## 🧪 How has this been tested?

* [ ] Manuellt testad
* [x] Enhetstester körda
* [x] Testad via API / UI

Beskriv kort:

* Kört controller-tester med OpenAPI contract validation
* Kört backend-tester via Gradle
* Validerat `backend/docs/api-spec.yaml` med Redocly
* Verifierat att success responses matchar OpenAPI-spec för Auth, Admin, Address och Report endpoints

Kommandon:

```powershell
.\gradlew.bat test --tests "se.voizter.felparkering.api.controller.*"
npx.cmd --yes @redocly/cli lint backend/docs/api-spec.yaml
```

---

## 📸 Screenshots / Examples (valfri)

Exempel på standardiserad success response:

```json
{
  "data": {
    "id": 12,
    "status": "NEW"
  },
  "message": "Report fetched successfully"
}
```

Exempel på standardiserad error response:

```json
{
  "error": {
    "code": "NOT_FOUND",
    "message": "Report not found"
  }
}
```

Exempel på validation response:

```json
{
  "errors": [
    {
      "field": "email",
      "message": "Invalid email address"
    }
  ]
}
```

---

## 🧠 Notes / Things to review

* Kontrollera att response-formaten känns rimliga för frontend
* Granska DTO-strukturen och att inga JPA entities läcker i API-kontraktet
* Kontrollera att `api-spec.yaml` matchar controller-responses
* Error response OpenAPI-validation är planerad som separat nästa task

---

## ✅ Checklist

* [x] Koden bygger
* [x] Tester passerar
* [x] PR kopplad till Jira issue
* [x] Ingen debug-kod kvar
* [x] Rimlig kodstruktur